### PR TITLE
Add cross-platform deploy support (Epic 2)

### DIFF
--- a/src/Perch.Cli/Perch.Cli.csproj
+++ b/src/Perch.Cli/Perch.Cli.csproj
@@ -2,6 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>perch</ToolCommandName>
+    <PackageId>Perch.Cli</PackageId>
+    <Version>0.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Perch.Core/Deploy/DeployService.cs
+++ b/src/Perch.Core/Deploy/DeployService.cs
@@ -7,11 +7,15 @@ public sealed class DeployService : IDeployService
 {
     private readonly IModuleDiscoveryService _discoveryService;
     private readonly SymlinkOrchestrator _orchestrator;
+    private readonly IPlatformDetector _platformDetector;
+    private readonly IGlobResolver _globResolver;
 
-    public DeployService(IModuleDiscoveryService discoveryService, SymlinkOrchestrator orchestrator)
+    public DeployService(IModuleDiscoveryService discoveryService, SymlinkOrchestrator orchestrator, IPlatformDetector platformDetector, IGlobResolver globResolver)
     {
         _discoveryService = discoveryService;
         _orchestrator = orchestrator;
+        _platformDetector = platformDetector;
+        _globResolver = globResolver;
     }
 
     public async Task<int> DeployAsync(string configRepoPath, IProgress<DeployResult>? progress = null, CancellationToken cancellationToken = default)
@@ -24,22 +28,49 @@ public sealed class DeployService : IDeployService
         }
 
         bool hasErrors = discovery.Errors.Length > 0;
+        Platform currentPlatform = _platformDetector.CurrentPlatform;
 
         foreach (AppModule module in discovery.Modules)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
+            if (module.Platforms.Length > 0 && !module.Platforms.Contains(currentPlatform))
+            {
+                progress?.Report(new DeployResult(module.DisplayName, "", "", ResultLevel.Ok,
+                    $"Skipped (not for {currentPlatform})"));
+                continue;
+            }
+
             foreach (LinkEntry link in module.Links)
             {
-                string expandedTarget = EnvironmentExpander.Expand(link.Target);
+                string? target = link.GetTargetForPlatform(currentPlatform);
+                if (target == null)
+                {
+                    progress?.Report(new DeployResult(module.DisplayName, link.Source, "", ResultLevel.Ok,
+                        $"Skipped (no target for {currentPlatform})"));
+                    continue;
+                }
+
+                string expandedTarget = EnvironmentExpander.Expand(target);
                 string sourcePath = Path.GetFullPath(Path.Combine(module.ModulePath, link.Source));
 
-                DeployResult result = _orchestrator.ProcessLink(module.DisplayName, sourcePath, expandedTarget, link.LinkType);
-                progress?.Report(result);
-
-                if (result.Level == ResultLevel.Error)
+                IReadOnlyList<string> resolvedTargets = _globResolver.Resolve(expandedTarget);
+                if (resolvedTargets.Count == 0)
                 {
-                    hasErrors = true;
+                    progress?.Report(new DeployResult(module.DisplayName, sourcePath, expandedTarget, ResultLevel.Warning,
+                        "No matches for glob pattern"));
+                    continue;
+                }
+
+                foreach (string resolvedTarget in resolvedTargets)
+                {
+                    DeployResult result = _orchestrator.ProcessLink(module.DisplayName, sourcePath, resolvedTarget, link.LinkType);
+                    progress?.Report(result);
+
+                    if (result.Level == ResultLevel.Error)
+                    {
+                        hasErrors = true;
+                    }
                 }
             }
         }

--- a/src/Perch.Core/IPlatformDetector.cs
+++ b/src/Perch.Core/IPlatformDetector.cs
@@ -1,0 +1,6 @@
+namespace Perch.Core;
+
+public interface IPlatformDetector
+{
+    Platform CurrentPlatform { get; }
+}

--- a/src/Perch.Core/Modules/AppManifest.cs
+++ b/src/Perch.Core/Modules/AppManifest.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
+using Perch.Core;
 
 namespace Perch.Core.Modules;
 
-public sealed record AppManifest(string ModuleName, string DisplayName, ImmutableArray<LinkEntry> Links);
+public sealed record AppManifest(string ModuleName, string DisplayName, ImmutableArray<Platform> Platforms, ImmutableArray<LinkEntry> Links);

--- a/src/Perch.Core/Modules/AppModule.cs
+++ b/src/Perch.Core/Modules/AppModule.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
+using Perch.Core;
 
 namespace Perch.Core.Modules;
 
-public sealed record AppModule(string Name, string DisplayName, string ModulePath, ImmutableArray<LinkEntry> Links);
+public sealed record AppModule(string Name, string DisplayName, string ModulePath, ImmutableArray<Platform> Platforms, ImmutableArray<LinkEntry> Links);

--- a/src/Perch.Core/Modules/GlobResolver.cs
+++ b/src/Perch.Core/Modules/GlobResolver.cs
@@ -1,0 +1,57 @@
+namespace Perch.Core.Modules;
+
+public sealed class GlobResolver : IGlobResolver
+{
+    public IReadOnlyList<string> Resolve(string path)
+    {
+        if (!ContainsWildcard(path))
+        {
+            return [path];
+        }
+
+        string[] segments = path.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var current = new List<string> { "" };
+
+        for (int i = 0; i < segments.Length; i++)
+        {
+            string segment = segments[i];
+            var next = new List<string>();
+
+            if (!ContainsWildcard(segment))
+            {
+                foreach (string dir in current)
+                {
+                    next.Add(Path.Combine(dir, segment));
+                }
+            }
+            else
+            {
+                bool isLast = i == segments.Length - 1;
+                foreach (string dir in current)
+                {
+                    if (!Directory.Exists(dir))
+                    {
+                        continue;
+                    }
+
+                    if (isLast)
+                    {
+                        next.AddRange(Directory.GetDirectories(dir, segment));
+                        next.AddRange(Directory.GetFiles(dir, segment));
+                    }
+                    else
+                    {
+                        next.AddRange(Directory.GetDirectories(dir, segment));
+                    }
+                }
+            }
+
+            current = next;
+        }
+
+        return current;
+    }
+
+    private static bool ContainsWildcard(string value) =>
+        value.Contains('*') || value.Contains('?');
+}

--- a/src/Perch.Core/Modules/IGlobResolver.cs
+++ b/src/Perch.Core/Modules/IGlobResolver.cs
@@ -1,0 +1,6 @@
+namespace Perch.Core.Modules;
+
+public interface IGlobResolver
+{
+    IReadOnlyList<string> Resolve(string path);
+}

--- a/src/Perch.Core/Modules/LinkEntry.cs
+++ b/src/Perch.Core/Modules/LinkEntry.cs
@@ -1,3 +1,13 @@
+using System.Collections.Immutable;
+using Perch.Core;
+
 namespace Perch.Core.Modules;
 
-public sealed record LinkEntry(string Source, string Target, LinkType LinkType);
+public sealed record LinkEntry(string Source, string? Target, ImmutableDictionary<Platform, string>? PlatformTargets, LinkType LinkType)
+{
+    public LinkEntry(string source, string target, LinkType linkType)
+        : this(source, target, null, linkType) { }
+
+    public string? GetTargetForPlatform(Platform platform) =>
+        Target ?? (PlatformTargets?.TryGetValue(platform, out var t) == true ? t : null);
+}

--- a/src/Perch.Core/Modules/ManifestYamlModel.cs
+++ b/src/Perch.Core/Modules/ManifestYamlModel.cs
@@ -3,12 +3,13 @@ namespace Perch.Core.Modules;
 internal sealed class ManifestYamlModel
 {
     public string? DisplayName { get; set; }
+    public List<string>? Platforms { get; set; }
     public List<LinkYamlModel>? Links { get; set; }
 }
 
 internal sealed class LinkYamlModel
 {
     public string? Source { get; set; }
-    public string? Target { get; set; }
+    public object? Target { get; set; }
     public string? LinkType { get; set; }
 }

--- a/src/Perch.Core/Modules/ModuleDiscoveryService.cs
+++ b/src/Perch.Core/Modules/ModuleDiscoveryService.cs
@@ -42,7 +42,7 @@ public sealed class ModuleDiscoveryService : IModuleDiscoveryService
             if (parseResult.IsSuccess)
             {
                 AppManifest manifest = parseResult.Manifest!;
-                modules.Add(new AppModule(manifest.ModuleName, manifest.DisplayName, subdir, manifest.Links));
+                modules.Add(new AppModule(manifest.ModuleName, manifest.DisplayName, subdir, manifest.Platforms, manifest.Links));
             }
             else
             {

--- a/src/Perch.Core/Platform.cs
+++ b/src/Perch.Core/Platform.cs
@@ -1,0 +1,8 @@
+namespace Perch.Core;
+
+public enum Platform
+{
+    Windows,
+    Linux,
+    MacOS,
+}

--- a/src/Perch.Core/PlatformDetector.cs
+++ b/src/Perch.Core/PlatformDetector.cs
@@ -1,0 +1,9 @@
+namespace Perch.Core;
+
+public sealed class PlatformDetector : IPlatformDetector
+{
+    public Platform CurrentPlatform =>
+        OperatingSystem.IsWindows() ? Platform.Windows :
+        OperatingSystem.IsMacOS() ? Platform.MacOS :
+        Platform.Linux;
+}

--- a/src/Perch.Core/ServiceCollectionExtensions.cs
+++ b/src/Perch.Core/ServiceCollectionExtensions.cs
@@ -12,8 +12,17 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddPerchCore(this IServiceCollection services)
     {
         services.AddSingleton<ManifestParser>();
+        services.AddSingleton<IGlobResolver, GlobResolver>();
         services.AddSingleton<IModuleDiscoveryService, ModuleDiscoveryService>();
-        services.AddSingleton<ISymlinkProvider, WindowsSymlinkProvider>();
+        services.AddSingleton<IPlatformDetector, PlatformDetector>();
+        if (OperatingSystem.IsWindows())
+        {
+            services.AddSingleton<ISymlinkProvider, WindowsSymlinkProvider>();
+        }
+        else
+        {
+            services.AddSingleton<ISymlinkProvider, UnixSymlinkProvider>();
+        }
         services.AddSingleton<IFileBackupProvider, FileBackupProvider>();
         services.AddSingleton<SymlinkOrchestrator>();
         services.AddSingleton<IDeployService, DeployService>();

--- a/src/Perch.Core/Symlinks/UnixSymlinkProvider.cs
+++ b/src/Perch.Core/Symlinks/UnixSymlinkProvider.cs
@@ -1,0 +1,49 @@
+namespace Perch.Core.Symlinks;
+
+public sealed class UnixSymlinkProvider : ISymlinkProvider
+{
+    public void CreateSymlink(string linkPath, string targetPath)
+    {
+        if (File.Exists(targetPath))
+        {
+            File.CreateSymbolicLink(linkPath, targetPath);
+        }
+        else if (Directory.Exists(targetPath))
+        {
+            Directory.CreateSymbolicLink(linkPath, targetPath);
+        }
+        else
+        {
+            File.CreateSymbolicLink(linkPath, targetPath);
+        }
+    }
+
+    public void CreateJunction(string linkPath, string targetPath)
+    {
+        Directory.CreateSymbolicLink(linkPath, targetPath);
+    }
+
+    public bool IsSymlink(string path)
+    {
+        var info = new FileInfo(path);
+        if (info.Exists)
+        {
+            return info.LinkTarget != null;
+        }
+
+        var dirInfo = new DirectoryInfo(path);
+        return dirInfo.Exists && dirInfo.LinkTarget != null;
+    }
+
+    public string? GetSymlinkTarget(string path)
+    {
+        var info = new FileInfo(path);
+        if (info.Exists)
+        {
+            return info.LinkTarget;
+        }
+
+        var dirInfo = new DirectoryInfo(path);
+        return dirInfo.Exists ? dirInfo.LinkTarget : null;
+    }
+}

--- a/tests/Perch.Core.Tests/Deploy/DeployServiceTests.cs
+++ b/tests/Perch.Core.Tests/Deploy/DeployServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using Perch.Core;
 using Perch.Core.Backup;
 using Perch.Core.Deploy;
 using Perch.Core.Modules;
@@ -12,6 +13,8 @@ public sealed class DeployServiceTests
     private IModuleDiscoveryService _discoveryService = null!;
     private ISymlinkProvider _symlinkProvider = null!;
     private IFileBackupProvider _backupProvider = null!;
+    private IPlatformDetector _platformDetector = null!;
+    private IGlobResolver _globResolver = null!;
     private DeployService _deployService = null!;
     private List<DeployResult> _reported = null!;
     private Progress<DeployResult> _progress = null!;
@@ -22,8 +25,12 @@ public sealed class DeployServiceTests
         _discoveryService = Substitute.For<IModuleDiscoveryService>();
         _symlinkProvider = Substitute.For<ISymlinkProvider>();
         _backupProvider = Substitute.For<IFileBackupProvider>();
+        _platformDetector = Substitute.For<IPlatformDetector>();
+        _platformDetector.CurrentPlatform.Returns(Platform.Windows);
+        _globResolver = Substitute.For<IGlobResolver>();
+        _globResolver.Resolve(Arg.Any<string>()).Returns(x => new[] { x.Arg<string>() });
         var orchestrator = new SymlinkOrchestrator(_symlinkProvider, _backupProvider);
-        _deployService = new DeployService(_discoveryService, orchestrator);
+        _deployService = new DeployService(_discoveryService, orchestrator, _platformDetector, _globResolver);
         _reported = new List<DeployResult>();
         _progress = new Progress<DeployResult>(r => _reported.Add(r));
     }
@@ -43,9 +50,9 @@ public sealed class DeployServiceTests
         try
         {
             var modules = ImmutableArray.Create(
-                new AppModule("a", "Module A", moduleAPath, ImmutableArray.Create(
+                new AppModule("a", "Module A", moduleAPath, ImmutableArray<Platform>.Empty, ImmutableArray.Create(
                     new LinkEntry("file.txt", Path.Combine(targetDir, "a.txt"), LinkType.Symlink))),
-                new AppModule("b", "Module B", moduleBPath, ImmutableArray.Create(
+                new AppModule("b", "Module B", moduleBPath, ImmutableArray<Platform>.Empty, ImmutableArray.Create(
                     new LinkEntry("file.txt", Path.Combine(targetDir, "b.txt"), LinkType.Symlink))));
             _discoveryService.DiscoverAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns(new DiscoveryResult(modules, ImmutableArray<string>.Empty));
@@ -77,7 +84,7 @@ public sealed class DeployServiceTests
         try
         {
             var modules = ImmutableArray.Create(
-                new AppModule("mod", "Module", modulePath, ImmutableArray.Create(
+                new AppModule("mod", "Module", modulePath, ImmutableArray<Platform>.Empty, ImmutableArray.Create(
                     new LinkEntry("file.txt", Path.Combine(tempDir, "nonexistent", "sub", "a.txt"), LinkType.Symlink),
                     new LinkEntry("file2.txt", Path.Combine(tempDir, "a.txt"), LinkType.Symlink))));
             _discoveryService.DiscoverAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
@@ -103,7 +110,7 @@ public sealed class DeployServiceTests
         try
         {
             var modules = ImmutableArray.Create(
-                new AppModule("a", "A", Path.Combine(tempDir, "a"), ImmutableArray.Create(
+                new AppModule("a", "A", Path.Combine(tempDir, "a"), ImmutableArray<Platform>.Empty, ImmutableArray.Create(
                     new LinkEntry("f", Path.Combine(tempDir, "t"), LinkType.Symlink))));
             _discoveryService.DiscoverAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns(new DiscoveryResult(modules, ImmutableArray<string>.Empty));
@@ -134,7 +141,7 @@ public sealed class DeployServiceTests
         try
         {
             var modules = ImmutableArray.Create(
-                new AppModule("mod", "Module", modulePath, ImmutableArray.Create(
+                new AppModule("mod", "Module", modulePath, ImmutableArray<Platform>.Empty, ImmutableArray.Create(
                     new LinkEntry("file.txt", "%PERCH_TEST_DEPLOY%\\output.txt", LinkType.Symlink))));
             _discoveryService.DiscoverAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns(new DiscoveryResult(modules, ImmutableArray<string>.Empty));
@@ -165,7 +172,7 @@ public sealed class DeployServiceTests
         try
         {
             var modules = ImmutableArray.Create(
-                new AppModule("vscode", "VS Code", modulePath, ImmutableArray.Create(
+                new AppModule("vscode", "VS Code", modulePath, ImmutableArray<Platform>.Empty, ImmutableArray.Create(
                     new LinkEntry("settings.json", Path.Combine(targetDir, "settings.json"), LinkType.Symlink))));
             _discoveryService.DiscoverAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns(new DiscoveryResult(modules, ImmutableArray<string>.Empty));
@@ -174,6 +181,241 @@ public sealed class DeployServiceTests
 
             string expectedSource = Path.Combine(modulePath, "settings.json");
             _symlinkProvider.Received(1).CreateSymlink(Arg.Any<string>(), expectedSource);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Test]
+    public async Task DeployAsync_ModulePlatformMismatch_SkipsModule()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), $"perch-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            _platformDetector.CurrentPlatform.Returns(Platform.Windows);
+            var modules = ImmutableArray.Create(
+                new AppModule("linux-only", "Linux Only", Path.Combine(tempDir, "mod"), ImmutableArray.Create(Platform.Linux), ImmutableArray.Create(
+                    new LinkEntry("f", Path.Combine(tempDir, "t"), LinkType.Symlink))));
+            _discoveryService.DiscoverAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+                .Returns(new DiscoveryResult(modules, ImmutableArray<string>.Empty));
+
+            int exitCode = await _deployService.DeployAsync(tempDir, _progress);
+
+            await Task.Delay(50);
+            Assert.Multiple(() =>
+            {
+                Assert.That(exitCode, Is.EqualTo(0));
+                Assert.That(_reported, Has.Count.EqualTo(1));
+                Assert.That(_reported[0].Message, Does.Contain("Skipped"));
+            });
+            _symlinkProvider.DidNotReceive().CreateSymlink(Arg.Any<string>(), Arg.Any<string>());
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Test]
+    public async Task DeployAsync_ModulePlatformMatch_ProcessesModule()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), $"perch-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        string modulePath = Path.Combine(tempDir, "mod");
+        Directory.CreateDirectory(modulePath);
+        string targetDir = Path.Combine(tempDir, "target");
+        Directory.CreateDirectory(targetDir);
+
+        try
+        {
+            _platformDetector.CurrentPlatform.Returns(Platform.Windows);
+            var modules = ImmutableArray.Create(
+                new AppModule("win-mod", "Windows Module", modulePath, ImmutableArray.Create(Platform.Windows), ImmutableArray.Create(
+                    new LinkEntry("f.txt", Path.Combine(targetDir, "f.txt"), LinkType.Symlink))));
+            _discoveryService.DiscoverAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+                .Returns(new DiscoveryResult(modules, ImmutableArray<string>.Empty));
+
+            await _deployService.DeployAsync(tempDir, _progress);
+
+            _symlinkProvider.Received(1).CreateSymlink(Arg.Any<string>(), Arg.Any<string>());
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Test]
+    public async Task DeployAsync_ModuleNoPlatforms_ProcessesOnAllPlatforms()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), $"perch-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        string modulePath = Path.Combine(tempDir, "mod");
+        Directory.CreateDirectory(modulePath);
+        string targetDir = Path.Combine(tempDir, "target");
+        Directory.CreateDirectory(targetDir);
+
+        try
+        {
+            var modules = ImmutableArray.Create(
+                new AppModule("all-plat", "All Platforms", modulePath, ImmutableArray<Platform>.Empty, ImmutableArray.Create(
+                    new LinkEntry("f.txt", Path.Combine(targetDir, "f.txt"), LinkType.Symlink))));
+            _discoveryService.DiscoverAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+                .Returns(new DiscoveryResult(modules, ImmutableArray<string>.Empty));
+
+            await _deployService.DeployAsync(tempDir, _progress);
+
+            _symlinkProvider.Received(1).CreateSymlink(Arg.Any<string>(), Arg.Any<string>());
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Test]
+    public async Task DeployAsync_PlatformSpecificTargetMatch_UsesCorrectTarget()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), $"perch-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        string modulePath = Path.Combine(tempDir, "mod");
+        Directory.CreateDirectory(modulePath);
+        string targetDir = Path.Combine(tempDir, "target");
+        Directory.CreateDirectory(targetDir);
+
+        try
+        {
+            _platformDetector.CurrentPlatform.Returns(Platform.Windows);
+            var platformTargets = ImmutableDictionary.CreateRange(new[]
+            {
+                KeyValuePair.Create(Platform.Windows, Path.Combine(targetDir, "win.txt")),
+                KeyValuePair.Create(Platform.Linux, "/home/test/lin.txt"),
+            });
+            var modules = ImmutableArray.Create(
+                new AppModule("mod", "Module", modulePath, ImmutableArray<Platform>.Empty, ImmutableArray.Create(
+                    new LinkEntry("f.txt", null, platformTargets, LinkType.Symlink))));
+            _discoveryService.DiscoverAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+                .Returns(new DiscoveryResult(modules, ImmutableArray<string>.Empty));
+
+            await _deployService.DeployAsync(tempDir, _progress);
+
+            _symlinkProvider.Received(1).CreateSymlink(Path.Combine(targetDir, "win.txt"), Arg.Any<string>());
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Test]
+    public async Task DeployAsync_PlatformSpecificTargetNoMatch_Skips()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), $"perch-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        string modulePath = Path.Combine(tempDir, "mod");
+        Directory.CreateDirectory(modulePath);
+
+        try
+        {
+            await Task.Delay(50);
+            _reported.Clear();
+            _platformDetector.CurrentPlatform.Returns(Platform.MacOS);
+            var platformTargets = ImmutableDictionary.CreateRange(new[]
+            {
+                KeyValuePair.Create(Platform.Windows, @"C:\test\win.txt"),
+            });
+            var modules = ImmutableArray.Create(
+                new AppModule("mod", "Module", modulePath, ImmutableArray<Platform>.Empty, ImmutableArray.Create(
+                    new LinkEntry("f.txt", null, platformTargets, LinkType.Symlink))));
+            _discoveryService.DiscoverAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+                .Returns(new DiscoveryResult(modules, ImmutableArray<string>.Empty));
+
+            int exitCode = await _deployService.DeployAsync(tempDir, _progress);
+
+            await Task.Delay(50);
+            Assert.Multiple(() =>
+            {
+                Assert.That(exitCode, Is.EqualTo(0));
+                Assert.That(_reported, Has.Count.EqualTo(1));
+                Assert.That(_reported[0].Message, Does.Contain("Skipped"));
+            });
+            _symlinkProvider.DidNotReceive().CreateSymlink(Arg.Any<string>(), Arg.Any<string>());
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Test]
+    public async Task DeployAsync_GlobTarget_ResolvesAndProcessesAll()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), $"perch-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        string modulePath = Path.Combine(tempDir, "mod");
+        Directory.CreateDirectory(modulePath);
+        string targetDir1 = Path.Combine(tempDir, "target1");
+        string targetDir2 = Path.Combine(tempDir, "target2");
+        Directory.CreateDirectory(targetDir1);
+        Directory.CreateDirectory(targetDir2);
+
+        try
+        {
+            string globTarget = Path.Combine(tempDir, "target*", "settings.json");
+            string resolved1 = Path.Combine(targetDir1, "settings.json");
+            string resolved2 = Path.Combine(targetDir2, "settings.json");
+            _globResolver.Resolve(globTarget).Returns(new[] { resolved1, resolved2 });
+
+            var modules = ImmutableArray.Create(
+                new AppModule("mod", "Module", modulePath, ImmutableArray<Platform>.Empty, ImmutableArray.Create(
+                    new LinkEntry("settings.json", globTarget, LinkType.Symlink))));
+            _discoveryService.DiscoverAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+                .Returns(new DiscoveryResult(modules, ImmutableArray<string>.Empty));
+
+            await _deployService.DeployAsync(tempDir, _progress);
+
+            _symlinkProvider.Received(2).CreateSymlink(Arg.Any<string>(), Arg.Any<string>());
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Test]
+    public async Task DeployAsync_GlobNoMatch_SkipsWithWarning()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), $"perch-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        string modulePath = Path.Combine(tempDir, "mod");
+        Directory.CreateDirectory(modulePath);
+
+        try
+        {
+            string globTarget = Path.Combine(tempDir, "nonexistent*", "settings.json");
+            _globResolver.Resolve(globTarget).Returns(Array.Empty<string>());
+
+            var modules = ImmutableArray.Create(
+                new AppModule("mod", "Module", modulePath, ImmutableArray<Platform>.Empty, ImmutableArray.Create(
+                    new LinkEntry("settings.json", globTarget, LinkType.Symlink))));
+            _discoveryService.DiscoverAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+                .Returns(new DiscoveryResult(modules, ImmutableArray<string>.Empty));
+
+            int exitCode = await _deployService.DeployAsync(tempDir, _progress);
+
+            await Task.Delay(50);
+            Assert.Multiple(() =>
+            {
+                Assert.That(exitCode, Is.EqualTo(0));
+                Assert.That(_reported, Has.Count.EqualTo(1));
+                Assert.That(_reported[0].Level, Is.EqualTo(ResultLevel.Warning));
+                Assert.That(_reported[0].Message, Does.Contain("glob"));
+            });
+            _symlinkProvider.DidNotReceive().CreateSymlink(Arg.Any<string>(), Arg.Any<string>());
         }
         finally
         {

--- a/tests/Perch.Core.Tests/Modules/GlobResolverTests.cs
+++ b/tests/Perch.Core.Tests/Modules/GlobResolverTests.cs
@@ -1,0 +1,91 @@
+using Perch.Core.Modules;
+
+namespace Perch.Core.Tests.Modules;
+
+[TestFixture]
+public sealed class GlobResolverTests
+{
+    private string _tempDir = null!;
+    private GlobResolver _resolver = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"perch-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _resolver = new GlobResolver();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    [Test]
+    public void Resolve_NoGlob_ReturnsSamePath()
+    {
+        string path = Path.Combine(_tempDir, "some", "path");
+
+        IReadOnlyList<string> result = _resolver.Resolve(path);
+
+        Assert.That(result, Has.Count.EqualTo(1));
+        Assert.That(result[0], Is.EqualTo(path));
+    }
+
+    [Test]
+    public void Resolve_DirectoryGlob_MatchesDirectories()
+    {
+        Directory.CreateDirectory(Path.Combine(_tempDir, "17.0_abc"));
+        Directory.CreateDirectory(Path.Combine(_tempDir, "other"));
+
+        string pattern = Path.Combine(_tempDir, "17.0_*");
+
+        IReadOnlyList<string> result = _resolver.Resolve(pattern);
+
+        Assert.That(result, Has.Count.EqualTo(1));
+        Assert.That(result[0], Does.EndWith("17.0_abc"));
+    }
+
+    [Test]
+    public void Resolve_DirectoryGlob_MultipleMatches_ReturnsAll()
+    {
+        Directory.CreateDirectory(Path.Combine(_tempDir, "17.0_abc"));
+        Directory.CreateDirectory(Path.Combine(_tempDir, "17.0_def"));
+        Directory.CreateDirectory(Path.Combine(_tempDir, "other"));
+
+        string pattern = Path.Combine(_tempDir, "17.0_*");
+
+        IReadOnlyList<string> result = _resolver.Resolve(pattern);
+
+        Assert.That(result, Has.Count.EqualTo(2));
+    }
+
+    [Test]
+    public void Resolve_DirectoryGlob_NoMatch_ReturnsEmpty()
+    {
+        Directory.CreateDirectory(Path.Combine(_tempDir, "other"));
+
+        string pattern = Path.Combine(_tempDir, "17.0_*");
+
+        IReadOnlyList<string> result = _resolver.Resolve(pattern);
+
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public void Resolve_FileGlob_MatchesFiles()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "settings.json"), "{}");
+        File.WriteAllText(Path.Combine(_tempDir, "settings.bak"), "{}");
+
+        string pattern = Path.Combine(_tempDir, "settings.*");
+
+        IReadOnlyList<string> result = _resolver.Resolve(pattern);
+
+        Assert.That(result, Has.Count.EqualTo(2));
+    }
+}

--- a/tests/Perch.Core.Tests/Modules/LinkEntryTests.cs
+++ b/tests/Perch.Core.Tests/Modules/LinkEntryTests.cs
@@ -1,0 +1,50 @@
+using System.Collections.Immutable;
+using Perch.Core;
+using Perch.Core.Modules;
+
+namespace Perch.Core.Tests.Modules;
+
+[TestFixture]
+public sealed class LinkEntryTests
+{
+    [Test]
+    public void GetTargetForPlatform_SimpleTarget_ReturnsTarget()
+    {
+        var entry = new LinkEntry("src", "target-path", LinkType.Symlink);
+
+        string? result = entry.GetTargetForPlatform(Platform.Windows);
+
+        Assert.That(result, Is.EqualTo("target-path"));
+    }
+
+    [Test]
+    public void GetTargetForPlatform_PlatformMatch_ReturnsPlatformTarget()
+    {
+        var targets = ImmutableDictionary.CreateRange(new[]
+        {
+            KeyValuePair.Create(Platform.Windows, @"C:\Users\test\config"),
+            KeyValuePair.Create(Platform.Linux, "/home/test/config"),
+        });
+        var entry = new LinkEntry("src", null, targets, LinkType.Symlink);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(entry.GetTargetForPlatform(Platform.Windows), Is.EqualTo(@"C:\Users\test\config"));
+            Assert.That(entry.GetTargetForPlatform(Platform.Linux), Is.EqualTo("/home/test/config"));
+        });
+    }
+
+    [Test]
+    public void GetTargetForPlatform_NoMatch_ReturnsNull()
+    {
+        var targets = ImmutableDictionary.CreateRange(new[]
+        {
+            KeyValuePair.Create(Platform.Linux, "/home/test/config"),
+        });
+        var entry = new LinkEntry("src", null, targets, LinkType.Symlink);
+
+        string? result = entry.GetTargetForPlatform(Platform.MacOS);
+
+        Assert.That(result, Is.Null);
+    }
+}

--- a/tests/Perch.Core.Tests/PlatformDetectorTests.cs
+++ b/tests/Perch.Core.Tests/PlatformDetectorTests.cs
@@ -1,0 +1,17 @@
+using Perch.Core;
+
+namespace Perch.Core.Tests;
+
+[TestFixture]
+public sealed class PlatformDetectorTests
+{
+    [Test]
+    public void CurrentPlatform_ReturnsValidPlatform()
+    {
+        var detector = new PlatformDetector();
+
+        Platform result = detector.CurrentPlatform;
+
+        Assert.That(result, Is.AnyOf(Platform.Windows, Platform.Linux, Platform.MacOS));
+    }
+}

--- a/tests/Perch.Core.Tests/Symlinks/UnixSymlinkProviderTests.cs
+++ b/tests/Perch.Core.Tests/Symlinks/UnixSymlinkProviderTests.cs
@@ -1,0 +1,87 @@
+using Perch.Core.Symlinks;
+
+namespace Perch.Core.Tests.Symlinks;
+
+[TestFixture]
+[Platform("Linux,MacOsX")]
+public sealed class UnixSymlinkProviderTests
+{
+    private string _tempDir = null!;
+    private UnixSymlinkProvider _provider = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"perch-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _provider = new UnixSymlinkProvider();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    [Test]
+    public void CreateSymlink_File_CreatesSymbolicLink()
+    {
+        string targetPath = Path.Combine(_tempDir, "target.txt");
+        File.WriteAllText(targetPath, "content");
+        string linkPath = Path.Combine(_tempDir, "link.txt");
+
+        _provider.CreateSymlink(linkPath, targetPath);
+
+        Assert.That(File.Exists(linkPath), Is.True);
+        Assert.That(new FileInfo(linkPath).LinkTarget, Is.Not.Null);
+    }
+
+    [Test]
+    public void CreateJunction_FallsBackToDirectorySymlink()
+    {
+        string targetDir = Path.Combine(_tempDir, "targetdir");
+        Directory.CreateDirectory(targetDir);
+        string linkPath = Path.Combine(_tempDir, "linkdir");
+
+        _provider.CreateJunction(linkPath, targetDir);
+
+        Assert.That(Directory.Exists(linkPath), Is.True);
+        Assert.That(new DirectoryInfo(linkPath).LinkTarget, Is.Not.Null);
+    }
+
+    [Test]
+    public void IsSymlink_Symlink_ReturnsTrue()
+    {
+        string targetPath = Path.Combine(_tempDir, "target.txt");
+        File.WriteAllText(targetPath, "content");
+        string linkPath = Path.Combine(_tempDir, "link.txt");
+        File.CreateSymbolicLink(linkPath, targetPath);
+
+        Assert.That(_provider.IsSymlink(linkPath), Is.True);
+    }
+
+    [Test]
+    public void IsSymlink_RegularFile_ReturnsFalse()
+    {
+        string filePath = Path.Combine(_tempDir, "regular.txt");
+        File.WriteAllText(filePath, "content");
+
+        Assert.That(_provider.IsSymlink(filePath), Is.False);
+    }
+
+    [Test]
+    public void GetSymlinkTarget_Symlink_ReturnsTarget()
+    {
+        string targetPath = Path.Combine(_tempDir, "target.txt");
+        File.WriteAllText(targetPath, "content");
+        string linkPath = Path.Combine(_tempDir, "link.txt");
+        File.CreateSymbolicLink(linkPath, targetPath);
+
+        string? result = _provider.GetSymlinkTarget(linkPath);
+
+        Assert.That(result, Is.EqualTo(targetPath));
+    }
+}


### PR DESCRIPTION
Platform-aware manifests with optional `platforms` filter and polymorphic `target` field (string or per-platform mapping). Glob pattern resolution for wildcard target paths. Unix symlink provider for Linux/macOS. Dotnet tool packaging for global install.