### PR TITLE
Add apps command with package manager scanning

### DIFF
--- a/src/Perch.Cli/Commands/AppsCommand.cs
+++ b/src/Perch.Cli/Commands/AppsCommand.cs
@@ -1,0 +1,133 @@
+using System.ComponentModel;
+using Perch.Core.Config;
+using Perch.Core.Packages;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Perch.Cli.Commands;
+
+public sealed class AppsCommand : AsyncCommand<AppsCommand.Settings>
+{
+    private readonly IAppScanService _appScanService;
+    private readonly ISettingsProvider _settingsProvider;
+    private readonly IAnsiConsole _console;
+
+    public sealed class Settings : CommandSettings
+    {
+        [CommandOption("--config-path")]
+        [Description("Path to the config repository")]
+        public string? ConfigPath { get; init; }
+
+        [CommandOption("--output")]
+        [Description("Output format (Pretty or Json)")]
+        public OutputFormat Output { get; init; } = OutputFormat.Pretty;
+
+        [CommandOption("--unmanaged")]
+        [Description("Show only installed apps without a config module")]
+        public bool Unmanaged { get; init; }
+    }
+
+    public AppsCommand(IAppScanService appScanService, ISettingsProvider settingsProvider, IAnsiConsole console)
+    {
+        _appScanService = appScanService;
+        _settingsProvider = settingsProvider;
+        _console = console;
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    {
+        string? configPath = settings.ConfigPath;
+
+        if (string.IsNullOrWhiteSpace(configPath))
+        {
+            PerchSettings perchSettings = await _settingsProvider.LoadAsync(cancellationToken);
+            configPath = perchSettings.ConfigRepoPath;
+        }
+
+        if (string.IsNullOrWhiteSpace(configPath))
+        {
+            _console.MarkupLine("[red]Error:[/] No config path specified. Use --config-path or set it in settings.");
+            return 2;
+        }
+
+        if (settings.Output == OutputFormat.Json)
+        {
+            return await ExecuteJsonAsync(configPath, settings.Unmanaged, cancellationToken);
+        }
+
+        return await ExecutePrettyAsync(configPath, settings.Unmanaged, cancellationToken);
+    }
+
+    private async Task<int> ExecutePrettyAsync(string configPath, bool unmanagedOnly, CancellationToken cancellationToken)
+    {
+        var result = await _appScanService.ScanAsync(configPath, cancellationToken);
+        var entries = unmanagedOnly
+            ? result.Entries.Where(e => e.Category == AppCategory.InstalledNoModule).ToList()
+            : result.Entries.ToList();
+
+        foreach (string warning in result.Warnings)
+        {
+            _console.MarkupLine($"[yellow]Warning:[/] {warning.EscapeMarkup()}");
+        }
+
+        if (entries.Count == 0)
+        {
+            if (unmanagedOnly)
+            {
+                _console.MarkupLine("[green]All installed apps are managed.[/]");
+            }
+            else
+            {
+                _console.MarkupLine("[grey]No apps found.[/]");
+            }
+            return 0;
+        }
+
+        var table = new Table();
+        table.AddColumn("Name");
+        table.AddColumn("Category");
+        table.AddColumn("Source");
+
+        foreach (var entry in entries)
+        {
+            string categoryDisplay = entry.Category switch
+            {
+                AppCategory.Managed => "[green]Managed[/]",
+                AppCategory.InstalledNoModule => "[yellow]No Module[/]",
+                AppCategory.DefinedNotInstalled => "[red]Not Installed[/]",
+                _ => "[grey]Unknown[/]",
+            };
+
+            table.AddRow(
+                entry.Name.EscapeMarkup(),
+                categoryDisplay,
+                entry.Source?.ToString() ?? "-");
+        }
+
+        _console.Write(table);
+        return 0;
+    }
+
+    private async Task<int> ExecuteJsonAsync(string configPath, bool unmanagedOnly, CancellationToken cancellationToken)
+    {
+        var result = await _appScanService.ScanAsync(configPath, cancellationToken);
+        var entries = unmanagedOnly
+            ? result.Entries.Where(e => e.Category == AppCategory.InstalledNoModule)
+            : result.Entries.AsEnumerable();
+
+        var output = new
+        {
+            entries = entries.Select(e => new
+            {
+                name = e.Name,
+                category = e.Category.ToString(),
+                source = e.Source?.ToString(),
+            }),
+            warnings = result.Warnings.AsEnumerable(),
+        };
+
+        string json = JsonSerializer.Serialize(output, new JsonSerializerOptions { WriteIndented = true });
+        _console.WriteLine(json);
+        return 0;
+    }
+}

--- a/src/Perch.Cli/Program.cs
+++ b/src/Perch.Cli/Program.cs
@@ -18,6 +18,8 @@ app.Configure(config =>
         .WithDescription("Deploy managed configs by creating symlinks");
     config.AddCommand<StatusCommand>("status")
         .WithDescription("Check for drift between managed configs and deployed symlinks");
+    config.AddCommand<AppsCommand>("apps")
+        .WithDescription("Show installed apps and their config module status");
 });
 
 return app.Run(args);

--- a/src/Perch.Core/Packages/AppCategory.cs
+++ b/src/Perch.Core/Packages/AppCategory.cs
@@ -1,0 +1,8 @@
+namespace Perch.Core.Packages;
+
+public enum AppCategory
+{
+    Managed,
+    InstalledNoModule,
+    DefinedNotInstalled,
+}

--- a/src/Perch.Core/Packages/AppEntry.cs
+++ b/src/Perch.Core/Packages/AppEntry.cs
@@ -1,0 +1,3 @@
+namespace Perch.Core.Packages;
+
+public sealed record AppEntry(string Name, AppCategory Category, PackageManager? Source);

--- a/src/Perch.Core/Packages/AppScanResult.cs
+++ b/src/Perch.Core/Packages/AppScanResult.cs
@@ -1,0 +1,7 @@
+using System.Collections.Immutable;
+
+namespace Perch.Core.Packages;
+
+public sealed record AppScanResult(
+    ImmutableArray<AppEntry> Entries,
+    ImmutableArray<string> Warnings);

--- a/src/Perch.Core/Packages/AppScanService.cs
+++ b/src/Perch.Core/Packages/AppScanService.cs
@@ -1,0 +1,92 @@
+using System.Collections.Immutable;
+using Perch.Core.Modules;
+
+namespace Perch.Core.Packages;
+
+public sealed class AppScanService : IAppScanService
+{
+    private readonly IModuleDiscoveryService _discoveryService;
+    private readonly PackageManifestParser _manifestParser;
+    private readonly IEnumerable<IPackageManagerProvider> _providers;
+
+    public AppScanService(
+        IModuleDiscoveryService discoveryService,
+        PackageManifestParser manifestParser,
+        IEnumerable<IPackageManagerProvider> providers)
+    {
+        _discoveryService = discoveryService;
+        _manifestParser = manifestParser;
+        _providers = providers;
+    }
+
+    public async Task<AppScanResult> ScanAsync(string configRepoPath, CancellationToken cancellationToken = default)
+    {
+        var warnings = new List<string>();
+
+        // 1. Discover modules
+        var discovery = await _discoveryService.DiscoverAsync(configRepoPath, cancellationToken).ConfigureAwait(false);
+        var moduleNames = discovery.Modules
+            .Select(m => m.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        // 2. Parse packages.yaml (optional)
+        var declaredPackages = ImmutableArray<PackageDefinition>.Empty;
+        string manifestPath = Path.Combine(configRepoPath, "packages.yaml");
+        if (File.Exists(manifestPath))
+        {
+            string yaml = await File.ReadAllTextAsync(manifestPath, cancellationToken).ConfigureAwait(false);
+            var parseResult = _manifestParser.Parse(yaml);
+            if (parseResult.IsSuccess)
+            {
+                declaredPackages = parseResult.Packages;
+            }
+            foreach (string error in parseResult.Errors)
+            {
+                warnings.Add(error);
+            }
+        }
+
+        // 3. Scan installed packages from all providers
+        var installedPackages = new List<InstalledPackage>();
+        foreach (var provider in _providers)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var scanResult = await provider.ScanInstalledAsync(cancellationToken).ConfigureAwait(false);
+            if (scanResult.IsAvailable)
+            {
+                installedPackages.AddRange(scanResult.Packages);
+            }
+            else if (scanResult.ErrorMessage != null)
+            {
+                warnings.Add(scanResult.ErrorMessage);
+            }
+        }
+
+        // 4. Cross-reference
+        var entries = new List<AppEntry>();
+        var installedByName = installedPackages
+            .GroupBy(p => p.Name, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
+
+        // Check installed packages
+        foreach (var installed in installedByName.Values)
+        {
+            bool hasModule = moduleNames.Contains(installed.Name);
+            var category = hasModule ? AppCategory.Managed : AppCategory.InstalledNoModule;
+            entries.Add(new AppEntry(installed.Name, category, installed.Source));
+        }
+
+        // Check declared packages not found as installed
+        foreach (var declared in declaredPackages)
+        {
+            if (!installedByName.ContainsKey(declared.Name))
+            {
+                entries.Add(new AppEntry(declared.Name, AppCategory.DefinedNotInstalled, declared.Manager));
+            }
+        }
+
+        return new AppScanResult(
+            entries.OrderBy(e => e.Name, StringComparer.OrdinalIgnoreCase).ToImmutableArray(),
+            warnings.ToImmutableArray());
+    }
+}

--- a/src/Perch.Core/Packages/ChocolateyPackageManagerProvider.cs
+++ b/src/Perch.Core/Packages/ChocolateyPackageManagerProvider.cs
@@ -1,0 +1,63 @@
+using System.Collections.Immutable;
+using System.ComponentModel;
+
+namespace Perch.Core.Packages;
+
+public sealed class ChocolateyPackageManagerProvider : IPackageManagerProvider
+{
+    private readonly IProcessRunner _processRunner;
+
+    public ChocolateyPackageManagerProvider(IProcessRunner processRunner)
+    {
+        _processRunner = processRunner;
+    }
+
+    public PackageManager Manager => PackageManager.Chocolatey;
+
+    public async Task<PackageManagerScanResult> ScanInstalledAsync(CancellationToken cancellationToken = default)
+    {
+        ProcessRunResult result;
+        try
+        {
+            result = await _processRunner.RunAsync("choco", "list", cancellationToken).ConfigureAwait(false);
+        }
+        catch (Win32Exception)
+        {
+            return PackageManagerScanResult.Unavailable("chocolatey is not installed.");
+        }
+
+        if (result.ExitCode != 0)
+        {
+            return PackageManagerScanResult.Unavailable($"choco list failed: {result.StandardError}");
+        }
+
+        var packages = ParseOutput(result.StandardOutput);
+        return new PackageManagerScanResult(true, packages, null);
+    }
+
+    internal static ImmutableArray<InstalledPackage> ParseOutput(string output)
+    {
+        var packages = new List<InstalledPackage>();
+
+        foreach (string line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            string trimmed = line.Trim();
+
+            if (string.IsNullOrWhiteSpace(trimmed))
+                continue;
+
+            // Skip summary lines like "42 packages installed."
+            if (trimmed.EndsWith("installed.", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            // choco list outputs "name version" per line
+            string[] parts = trimmed.Split(' ', 2, StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length >= 1 && !parts[0].Contains('|'))
+            {
+                packages.Add(new InstalledPackage(parts[0], PackageManager.Chocolatey));
+            }
+        }
+
+        return packages.ToImmutableArray();
+    }
+}

--- a/src/Perch.Core/Packages/DefaultProcessRunner.cs
+++ b/src/Perch.Core/Packages/DefaultProcessRunner.cs
@@ -1,0 +1,34 @@
+using System.Diagnostics;
+
+namespace Perch.Core.Packages;
+
+public sealed class DefaultProcessRunner : IProcessRunner
+{
+    public async Task<ProcessRunResult> RunAsync(string fileName, string arguments, CancellationToken cancellationToken = default)
+    {
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = fileName,
+                Arguments = arguments,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            },
+        };
+
+        process.Start();
+
+        var stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+
+        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+
+        string stdout = await stdoutTask.ConfigureAwait(false);
+        string stderr = await stderrTask.ConfigureAwait(false);
+
+        return new ProcessRunResult(process.ExitCode, stdout, stderr);
+    }
+}

--- a/src/Perch.Core/Packages/IAppScanService.cs
+++ b/src/Perch.Core/Packages/IAppScanService.cs
@@ -1,0 +1,6 @@
+namespace Perch.Core.Packages;
+
+public interface IAppScanService
+{
+    Task<AppScanResult> ScanAsync(string configRepoPath, CancellationToken cancellationToken = default);
+}

--- a/src/Perch.Core/Packages/IPackageManagerProvider.cs
+++ b/src/Perch.Core/Packages/IPackageManagerProvider.cs
@@ -1,0 +1,7 @@
+namespace Perch.Core.Packages;
+
+public interface IPackageManagerProvider
+{
+    PackageManager Manager { get; }
+    Task<PackageManagerScanResult> ScanInstalledAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Perch.Core/Packages/IProcessRunner.cs
+++ b/src/Perch.Core/Packages/IProcessRunner.cs
@@ -1,0 +1,8 @@
+namespace Perch.Core.Packages;
+
+public interface IProcessRunner
+{
+    Task<ProcessRunResult> RunAsync(string fileName, string arguments, CancellationToken cancellationToken = default);
+}
+
+public sealed record ProcessRunResult(int ExitCode, string StandardOutput, string StandardError);

--- a/src/Perch.Core/Packages/InstalledPackage.cs
+++ b/src/Perch.Core/Packages/InstalledPackage.cs
@@ -1,0 +1,3 @@
+namespace Perch.Core.Packages;
+
+public sealed record InstalledPackage(string Name, PackageManager Source);

--- a/src/Perch.Core/Packages/PackageDefinition.cs
+++ b/src/Perch.Core/Packages/PackageDefinition.cs
@@ -1,0 +1,3 @@
+namespace Perch.Core.Packages;
+
+public sealed record PackageDefinition(string Name, PackageManager Manager);

--- a/src/Perch.Core/Packages/PackageManager.cs
+++ b/src/Perch.Core/Packages/PackageManager.cs
@@ -1,0 +1,7 @@
+namespace Perch.Core.Packages;
+
+public enum PackageManager
+{
+    Chocolatey,
+    Winget,
+}

--- a/src/Perch.Core/Packages/PackageManagerScanResult.cs
+++ b/src/Perch.Core/Packages/PackageManagerScanResult.cs
@@ -1,0 +1,12 @@
+using System.Collections.Immutable;
+
+namespace Perch.Core.Packages;
+
+public sealed record PackageManagerScanResult(
+    bool IsAvailable,
+    ImmutableArray<InstalledPackage> Packages,
+    string? ErrorMessage)
+{
+    public static PackageManagerScanResult Unavailable(string errorMessage) =>
+        new(false, ImmutableArray<InstalledPackage>.Empty, errorMessage);
+}

--- a/src/Perch.Core/Packages/PackageManifestParseResult.cs
+++ b/src/Perch.Core/Packages/PackageManifestParseResult.cs
@@ -1,0 +1,28 @@
+using System.Collections.Immutable;
+
+namespace Perch.Core.Packages;
+
+public sealed record PackageManifestParseResult
+{
+    public ImmutableArray<PackageDefinition> Packages { get; }
+    public ImmutableArray<string> Errors { get; }
+    public bool IsSuccess => Packages.Length > 0 || Errors.Length == 0;
+
+    private PackageManifestParseResult(ImmutableArray<PackageDefinition> packages, ImmutableArray<string> errors)
+    {
+        Packages = packages;
+        Errors = errors;
+    }
+
+    public static PackageManifestParseResult Success(ImmutableArray<PackageDefinition> packages) =>
+        new(packages, ImmutableArray<string>.Empty);
+
+    public static PackageManifestParseResult PartialSuccess(ImmutableArray<PackageDefinition> packages, ImmutableArray<string> errors) =>
+        new(packages, errors);
+
+    public static PackageManifestParseResult Failure(ImmutableArray<string> errors) =>
+        new(ImmutableArray<PackageDefinition>.Empty, errors);
+
+    public static PackageManifestParseResult Failure(string error) =>
+        new(ImmutableArray<PackageDefinition>.Empty, ImmutableArray.Create(error));
+}

--- a/src/Perch.Core/Packages/PackageManifestParser.cs
+++ b/src/Perch.Core/Packages/PackageManifestParser.cs
@@ -1,0 +1,71 @@
+using System.Collections.Immutable;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Perch.Core.Packages;
+
+public sealed class PackageManifestParser
+{
+    private static readonly IDeserializer Deserializer = new DeserializerBuilder()
+        .WithNamingConvention(HyphenatedNamingConvention.Instance)
+        .IgnoreUnmatchedProperties()
+        .Build();
+
+    public PackageManifestParseResult Parse(string yaml)
+    {
+        if (string.IsNullOrWhiteSpace(yaml))
+        {
+            return PackageManifestParseResult.Failure("Package manifest is empty.");
+        }
+
+        PackageYamlModel model;
+        try
+        {
+            model = Deserializer.Deserialize<PackageYamlModel>(yaml);
+        }
+        catch (Exception ex)
+        {
+            return PackageManifestParseResult.Failure($"Invalid YAML: {ex.Message}");
+        }
+
+        if (model?.Packages == null || model.Packages.Count == 0)
+        {
+            return PackageManifestParseResult.Failure("Package manifest must contain at least one entry in 'packages'.");
+        }
+
+        var packages = new List<PackageDefinition>();
+        var errors = new List<string>();
+
+        for (int i = 0; i < model.Packages.Count; i++)
+        {
+            var entry = model.Packages[i];
+
+            if (string.IsNullOrWhiteSpace(entry.Name))
+            {
+                errors.Add($"Package [{i}] is missing 'name'.");
+                continue;
+            }
+
+            if (string.IsNullOrWhiteSpace(entry.Manager) ||
+                !Enum.TryParse<PackageManager>(entry.Manager, ignoreCase: true, out var manager))
+            {
+                errors.Add($"Package [{i}] '{entry.Name}' has unknown or missing 'manager': '{entry.Manager}'.");
+                continue;
+            }
+
+            packages.Add(new PackageDefinition(entry.Name, manager));
+        }
+
+        if (packages.Count > 0 && errors.Count > 0)
+        {
+            return PackageManifestParseResult.PartialSuccess(packages.ToImmutableArray(), errors.ToImmutableArray());
+        }
+
+        if (packages.Count > 0)
+        {
+            return PackageManifestParseResult.Success(packages.ToImmutableArray());
+        }
+
+        return PackageManifestParseResult.Failure(errors.ToImmutableArray());
+    }
+}

--- a/src/Perch.Core/Packages/PackageYamlModel.cs
+++ b/src/Perch.Core/Packages/PackageYamlModel.cs
@@ -1,0 +1,12 @@
+namespace Perch.Core.Packages;
+
+internal sealed class PackageYamlModel
+{
+    public List<PackageEntryYamlModel>? Packages { get; set; }
+}
+
+internal sealed class PackageEntryYamlModel
+{
+    public string? Name { get; set; }
+    public string? Manager { get; set; }
+}

--- a/src/Perch.Core/Packages/WingetPackageManagerProvider.cs
+++ b/src/Perch.Core/Packages/WingetPackageManagerProvider.cs
@@ -1,0 +1,122 @@
+using System.Collections.Immutable;
+using System.ComponentModel;
+
+namespace Perch.Core.Packages;
+
+public sealed class WingetPackageManagerProvider : IPackageManagerProvider
+{
+    private readonly IProcessRunner _processRunner;
+
+    public WingetPackageManagerProvider(IProcessRunner processRunner)
+    {
+        _processRunner = processRunner;
+    }
+
+    public PackageManager Manager => PackageManager.Winget;
+
+    public async Task<PackageManagerScanResult> ScanInstalledAsync(CancellationToken cancellationToken = default)
+    {
+        ProcessRunResult result;
+        try
+        {
+            result = await _processRunner.RunAsync("winget", "list --source winget", cancellationToken).ConfigureAwait(false);
+        }
+        catch (Win32Exception)
+        {
+            return PackageManagerScanResult.Unavailable("winget is not installed.");
+        }
+
+        if (result.ExitCode != 0)
+        {
+            return PackageManagerScanResult.Unavailable($"winget list failed: {result.StandardError}");
+        }
+
+        var packages = ParseOutput(result.StandardOutput);
+        return new PackageManagerScanResult(true, packages, null);
+    }
+
+    internal static ImmutableArray<InstalledPackage> ParseOutput(string output)
+    {
+        var packages = new List<InstalledPackage>();
+        string[] lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        // Find the header separator line (dashes)
+        int dataStartIndex = -1;
+        for (int i = 0; i < lines.Length; i++)
+        {
+            if (lines[i].TrimStart().StartsWith('-') && lines[i].Contains("--"))
+            {
+                dataStartIndex = i + 1;
+                break;
+            }
+        }
+
+        if (dataStartIndex < 0 || dataStartIndex >= lines.Length)
+        {
+            return ImmutableArray<InstalledPackage>.Empty;
+        }
+
+        // The header line is right before the separator
+        string headerLine = lines[dataStartIndex - 2];
+        string separatorLine = lines[dataStartIndex - 1];
+
+        // Find column boundaries from separator line
+        int idColumnStart = FindColumnStart(separatorLine, 1);
+        if (idColumnStart < 0)
+        {
+            return ImmutableArray<InstalledPackage>.Empty;
+        }
+
+        for (int i = dataStartIndex; i < lines.Length; i++)
+        {
+            string line = lines[i];
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+
+            // Extract the Name column (from start to idColumnStart)
+            if (line.Length > idColumnStart)
+            {
+                string name = line[..idColumnStart].Trim();
+                if (!string.IsNullOrWhiteSpace(name))
+                {
+                    packages.Add(new InstalledPackage(name, PackageManager.Winget));
+                }
+            }
+        }
+
+        return packages.ToImmutableArray();
+    }
+
+    private static int FindColumnStart(string separatorLine, int columnIndex)
+    {
+        int current = 0;
+        int found = 0;
+        bool inDashes = separatorLine.Length > 0 && separatorLine[0] == '-';
+
+        for (int i = 0; i < separatorLine.Length; i++)
+        {
+            bool isDash = separatorLine[i] == '-';
+
+            if (inDashes && !isDash)
+            {
+                inDashes = false;
+            }
+            else if (!inDashes && isDash)
+            {
+                inDashes = true;
+                found++;
+                if (found > columnIndex)
+                {
+                    return -1;
+                }
+                current = i;
+                if (found == columnIndex)
+                {
+                    return current;
+                }
+            }
+        }
+
+        return -1;
+    }
+}

--- a/src/Perch.Core/ServiceCollectionExtensions.cs
+++ b/src/Perch.Core/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using Perch.Core.Backup;
 using Perch.Core.Config;
 using Perch.Core.Deploy;
 using Perch.Core.Modules;
+using Perch.Core.Packages;
 using Perch.Core.Status;
 using Perch.Core.Symlinks;
 
@@ -32,6 +33,11 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IDeployService, DeployService>();
         services.AddSingleton<IStatusService, StatusService>();
         services.AddSingleton<ISettingsProvider, YamlSettingsProvider>();
+        services.AddSingleton<PackageManifestParser>();
+        services.AddSingleton<IProcessRunner, DefaultProcessRunner>();
+        services.AddSingleton<IPackageManagerProvider, ChocolateyPackageManagerProvider>();
+        services.AddSingleton<IPackageManagerProvider, WingetPackageManagerProvider>();
+        services.AddSingleton<IAppScanService, AppScanService>();
         return services;
     }
 }

--- a/tests/Perch.Core.Tests/Packages/AppScanServiceTests.cs
+++ b/tests/Perch.Core.Tests/Packages/AppScanServiceTests.cs
@@ -1,0 +1,191 @@
+using System.Collections.Immutable;
+using Perch.Core.Modules;
+using Perch.Core.Packages;
+
+namespace Perch.Core.Tests.Packages;
+
+[TestFixture]
+public sealed class AppScanServiceTests
+{
+    private IModuleDiscoveryService _discoveryService = null!;
+    private PackageManifestParser _manifestParser = null!;
+    private IPackageManagerProvider _chocoProvider = null!;
+    private IPackageManagerProvider _wingetProvider = null!;
+    private AppScanService _service = null!;
+    private string _tempDir = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _discoveryService = Substitute.For<IModuleDiscoveryService>();
+        _manifestParser = new PackageManifestParser();
+        _chocoProvider = Substitute.For<IPackageManagerProvider>();
+        _chocoProvider.Manager.Returns(PackageManager.Chocolatey);
+        _wingetProvider = Substitute.For<IPackageManagerProvider>();
+        _wingetProvider.Manager.Returns(PackageManager.Winget);
+
+        _service = new AppScanService(_discoveryService, _manifestParser, new[] { _chocoProvider, _wingetProvider });
+
+        _tempDir = Path.Combine(Path.GetTempPath(), $"perch-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    [Test]
+    public async Task ScanAsync_AllManaged_AllCategorizedAsManaged()
+    {
+        SetupModules("git", "7zip");
+        SetupInstalledChoco("git", "7zip");
+        SetupInstalledWinget();
+
+        var result = await _service.ScanAsync(_tempDir);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Entries, Has.Length.EqualTo(2));
+            Assert.That(result.Entries.All(e => e.Category == AppCategory.Managed), Is.True);
+        });
+    }
+
+    [Test]
+    public async Task ScanAsync_InstalledNoModule_CategorizedCorrectly()
+    {
+        SetupModules("git");
+        SetupInstalledChoco("git", "notepadplusplus");
+        SetupInstalledWinget();
+
+        var result = await _service.ScanAsync(_tempDir);
+
+        var unmanaged = result.Entries.Single(e => e.Name == "notepadplusplus");
+        Assert.That(unmanaged.Category, Is.EqualTo(AppCategory.InstalledNoModule));
+    }
+
+    [Test]
+    public async Task ScanAsync_DefinedNotInstalled_CategorizedCorrectly()
+    {
+        SetupModules();
+        SetupInstalledChoco();
+        SetupInstalledWinget();
+        WritePackagesYaml("""
+            packages:
+              - name: ripgrep
+                manager: winget
+            """);
+
+        var result = await _service.ScanAsync(_tempDir);
+
+        var entry = result.Entries.Single(e => e.Name == "ripgrep");
+        Assert.Multiple(() =>
+        {
+            Assert.That(entry.Category, Is.EqualTo(AppCategory.DefinedNotInstalled));
+            Assert.That(entry.Source, Is.EqualTo(PackageManager.Winget));
+        });
+    }
+
+    [Test]
+    public async Task ScanAsync_MixedCategories_AllPresent()
+    {
+        SetupModules("git");
+        SetupInstalledChoco("git", "notepadplusplus");
+        SetupInstalledWinget();
+        WritePackagesYaml("""
+            packages:
+              - name: git
+                manager: chocolatey
+              - name: ripgrep
+                manager: winget
+            """);
+
+        var result = await _service.ScanAsync(_tempDir);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Entries.Single(e => e.Name == "git").Category, Is.EqualTo(AppCategory.Managed));
+            Assert.That(result.Entries.Single(e => e.Name == "notepadplusplus").Category, Is.EqualTo(AppCategory.InstalledNoModule));
+            Assert.That(result.Entries.Single(e => e.Name == "ripgrep").Category, Is.EqualTo(AppCategory.DefinedNotInstalled));
+        });
+    }
+
+    [Test]
+    public async Task ScanAsync_NoPackageManifest_ScansInstalledOnly()
+    {
+        SetupModules("git");
+        SetupInstalledChoco("git", "7zip");
+        SetupInstalledWinget();
+
+        var result = await _service.ScanAsync(_tempDir);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Entries, Has.Length.EqualTo(2));
+            Assert.That(result.Warnings, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task ScanAsync_NoManagersAvailable_ReturnsWarnings()
+    {
+        SetupModules();
+        _chocoProvider.ScanInstalledAsync(Arg.Any<CancellationToken>())
+            .Returns(PackageManagerScanResult.Unavailable("chocolatey is not installed."));
+        _wingetProvider.ScanInstalledAsync(Arg.Any<CancellationToken>())
+            .Returns(PackageManagerScanResult.Unavailable("winget is not installed."));
+
+        var result = await _service.ScanAsync(_tempDir);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Entries, Is.Empty);
+            Assert.That(result.Warnings, Has.Length.EqualTo(2));
+        });
+    }
+
+    [Test]
+    public async Task ScanAsync_Cancellation_Throws()
+    {
+        SetupModules();
+        var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        _chocoProvider.ScanInstalledAsync(Arg.Any<CancellationToken>())
+            .Returns<PackageManagerScanResult>(_ => throw new OperationCanceledException());
+
+        Assert.ThrowsAsync<OperationCanceledException>(
+            () => _service.ScanAsync(_tempDir, cts.Token));
+    }
+
+    private void SetupModules(params string[] names)
+    {
+        var modules = names.Select(n =>
+            new AppModule(n, n, Path.Combine(_tempDir, n), ImmutableArray<Platform>.Empty, ImmutableArray<LinkEntry>.Empty))
+            .ToImmutableArray();
+
+        _discoveryService.DiscoverAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new DiscoveryResult(modules, ImmutableArray<string>.Empty));
+    }
+
+    private void SetupInstalledChoco(params string[] names)
+    {
+        var packages = names.Select(n => new InstalledPackage(n, PackageManager.Chocolatey)).ToImmutableArray();
+        _chocoProvider.ScanInstalledAsync(Arg.Any<CancellationToken>())
+            .Returns(new PackageManagerScanResult(true, packages, null));
+    }
+
+    private void SetupInstalledWinget(params string[] names)
+    {
+        var packages = names.Select(n => new InstalledPackage(n, PackageManager.Winget)).ToImmutableArray();
+        _wingetProvider.ScanInstalledAsync(Arg.Any<CancellationToken>())
+            .Returns(new PackageManagerScanResult(true, packages, null));
+    }
+
+    private void WritePackagesYaml(string yaml)
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "packages.yaml"), yaml);
+    }
+}

--- a/tests/Perch.Core.Tests/Packages/ChocolateyPackageManagerProviderTests.cs
+++ b/tests/Perch.Core.Tests/Packages/ChocolateyPackageManagerProviderTests.cs
@@ -1,0 +1,74 @@
+using System.ComponentModel;
+using Perch.Core.Packages;
+
+namespace Perch.Core.Tests.Packages;
+
+[TestFixture]
+public sealed class ChocolateyPackageManagerProviderTests
+{
+    private IProcessRunner _processRunner = null!;
+    private ChocolateyPackageManagerProvider _provider = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _processRunner = Substitute.For<IProcessRunner>();
+        _provider = new ChocolateyPackageManagerProvider(_processRunner);
+    }
+
+    [Test]
+    public async Task ScanInstalled_ChocoAvailable_ParsesPackages()
+    {
+        string output = """
+            chocolatey 2.2.2
+            git 2.42.0
+            7zip 23.01
+            3 packages installed.
+            """;
+
+        _processRunner.RunAsync("choco", "list", Arg.Any<CancellationToken>())
+            .Returns(new ProcessRunResult(0, output, ""));
+
+        var result = await _provider.ScanInstalledAsync();
+
+        Assert.That(result.IsAvailable, Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Packages, Has.Length.EqualTo(3));
+            Assert.That(result.Packages[0].Name, Is.EqualTo("chocolatey"));
+            Assert.That(result.Packages[1].Name, Is.EqualTo("git"));
+            Assert.That(result.Packages[2].Name, Is.EqualTo("7zip"));
+            Assert.That(result.Packages.All(p => p.Source == PackageManager.Chocolatey), Is.True);
+        });
+    }
+
+    [Test]
+    public async Task ScanInstalled_ChocoNotInstalled_ReturnsUnavailable()
+    {
+        _processRunner.RunAsync("choco", "list", Arg.Any<CancellationToken>())
+            .Returns<ProcessRunResult>(_ => throw new Win32Exception("not found"));
+
+        var result = await _provider.ScanInstalledAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsAvailable, Is.False);
+            Assert.That(result.ErrorMessage, Does.Contain("not installed"));
+        });
+    }
+
+    [Test]
+    public async Task ScanInstalled_ChocoReturnsError_ReturnsUnavailable()
+    {
+        _processRunner.RunAsync("choco", "list", Arg.Any<CancellationToken>())
+            .Returns(new ProcessRunResult(1, "", "something went wrong"));
+
+        var result = await _provider.ScanInstalledAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsAvailable, Is.False);
+            Assert.That(result.ErrorMessage, Does.Contain("failed"));
+        });
+    }
+}

--- a/tests/Perch.Core.Tests/Packages/PackageManifestParserTests.cs
+++ b/tests/Perch.Core.Tests/Packages/PackageManifestParserTests.cs
@@ -1,0 +1,148 @@
+using Perch.Core.Packages;
+
+namespace Perch.Core.Tests.Packages;
+
+[TestFixture]
+public sealed class PackageManifestParserTests
+{
+    private PackageManifestParser _parser = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _parser = new PackageManifestParser();
+    }
+
+    [Test]
+    public void Parse_ValidPackages_ReturnsAll()
+    {
+        string yaml = """
+            packages:
+              - name: git
+                manager: winget
+              - name: 7zip
+                manager: chocolatey
+            """;
+
+        var result = _parser.Parse(yaml);
+
+        Assert.That(result.IsSuccess, Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Packages, Has.Length.EqualTo(2));
+            Assert.That(result.Packages[0].Name, Is.EqualTo("git"));
+            Assert.That(result.Packages[0].Manager, Is.EqualTo(PackageManager.Winget));
+            Assert.That(result.Packages[1].Name, Is.EqualTo("7zip"));
+            Assert.That(result.Packages[1].Manager, Is.EqualTo(PackageManager.Chocolatey));
+            Assert.That(result.Errors, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void Parse_MixedValidInvalid_ReturnsPartialSuccess()
+    {
+        string yaml = """
+            packages:
+              - name: git
+                manager: winget
+              - name: bad-pkg
+                manager: apt
+            """;
+
+        var result = _parser.Parse(yaml);
+
+        Assert.That(result.IsSuccess, Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Packages, Has.Length.EqualTo(1));
+            Assert.That(result.Packages[0].Name, Is.EqualTo("git"));
+            Assert.That(result.Errors, Has.Length.EqualTo(1));
+            Assert.That(result.Errors[0], Does.Contain("bad-pkg"));
+        });
+    }
+
+    [Test]
+    public void Parse_MissingName_ReportsError()
+    {
+        string yaml = """
+            packages:
+              - manager: winget
+            """;
+
+        var result = _parser.Parse(yaml);
+
+        Assert.That(result.IsSuccess, Is.False);
+        Assert.That(result.Errors[0], Does.Contain("name"));
+    }
+
+    [Test]
+    public void Parse_UnknownManager_ReportsError()
+    {
+        string yaml = """
+            packages:
+              - name: git
+                manager: apt
+            """;
+
+        var result = _parser.Parse(yaml);
+
+        Assert.That(result.IsSuccess, Is.False);
+        Assert.That(result.Errors[0], Does.Contain("apt"));
+    }
+
+    [Test]
+    public void Parse_EmptyPackages_ReturnsFailure()
+    {
+        string yaml = """
+            packages: []
+            """;
+
+        var result = _parser.Parse(yaml);
+
+        Assert.That(result.IsSuccess, Is.False);
+        Assert.That(result.Errors[0], Does.Contain("packages"));
+    }
+
+    [Test]
+    public void Parse_EmptyYaml_ReturnsFailure()
+    {
+        string yaml = "";
+
+        var result = _parser.Parse(yaml);
+
+        Assert.That(result.IsSuccess, Is.False);
+        Assert.That(result.Errors[0], Does.Contain("empty"));
+    }
+
+    [Test]
+    public void Parse_InvalidYaml_ReturnsFailure()
+    {
+        string yaml = "{{invalid yaml::";
+
+        var result = _parser.Parse(yaml);
+
+        Assert.That(result.IsSuccess, Is.False);
+        Assert.That(result.Errors[0], Does.Contain("Invalid YAML"));
+    }
+
+    [Test]
+    public void Parse_CaseInsensitiveManager_Parses()
+    {
+        string yaml = """
+            packages:
+              - name: git
+                manager: WinGet
+              - name: 7zip
+                manager: CHOCOLATEY
+            """;
+
+        var result = _parser.Parse(yaml);
+
+        Assert.That(result.IsSuccess, Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Packages[0].Manager, Is.EqualTo(PackageManager.Winget));
+            Assert.That(result.Packages[1].Manager, Is.EqualTo(PackageManager.Chocolatey));
+        });
+    }
+}

--- a/tests/Perch.Core.Tests/Packages/WingetPackageManagerProviderTests.cs
+++ b/tests/Perch.Core.Tests/Packages/WingetPackageManagerProviderTests.cs
@@ -1,0 +1,72 @@
+using System.ComponentModel;
+using Perch.Core.Packages;
+
+namespace Perch.Core.Tests.Packages;
+
+[TestFixture]
+public sealed class WingetPackageManagerProviderTests
+{
+    private IProcessRunner _processRunner = null!;
+    private WingetPackageManagerProvider _provider = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _processRunner = Substitute.For<IProcessRunner>();
+        _provider = new WingetPackageManagerProvider(_processRunner);
+    }
+
+    [Test]
+    public async Task ScanInstalled_WingetAvailable_ParsesPackages()
+    {
+        string output =
+            "Name                           Id                     Version\r\n" +
+            "------------------------------  ---------------------  -------\r\n" +
+            "Git                            Git.Git                2.42.0\r\n" +
+            "7-Zip                          7zip.7zip              23.01\r\n";
+
+        _processRunner.RunAsync("winget", "list --source winget", Arg.Any<CancellationToken>())
+            .Returns(new ProcessRunResult(0, output, ""));
+
+        var result = await _provider.ScanInstalledAsync();
+
+        Assert.That(result.IsAvailable, Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Packages, Has.Length.EqualTo(2));
+            Assert.That(result.Packages[0].Name, Is.EqualTo("Git"));
+            Assert.That(result.Packages[1].Name, Is.EqualTo("7-Zip"));
+            Assert.That(result.Packages.All(p => p.Source == PackageManager.Winget), Is.True);
+        });
+    }
+
+    [Test]
+    public async Task ScanInstalled_WingetNotInstalled_ReturnsUnavailable()
+    {
+        _processRunner.RunAsync("winget", "list --source winget", Arg.Any<CancellationToken>())
+            .Returns<ProcessRunResult>(_ => throw new Win32Exception("not found"));
+
+        var result = await _provider.ScanInstalledAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsAvailable, Is.False);
+            Assert.That(result.ErrorMessage, Does.Contain("not installed"));
+        });
+    }
+
+    [Test]
+    public async Task ScanInstalled_WingetReturnsError_ReturnsUnavailable()
+    {
+        _processRunner.RunAsync("winget", "list --source winget", Arg.Any<CancellationToken>())
+            .Returns(new ProcessRunResult(1, "", "error occurred"));
+
+        var result = await _provider.ScanInstalledAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsAvailable, Is.False);
+            Assert.That(result.ErrorMessage, Does.Contain("failed"));
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `apps` CLI command that scans installed packages via Chocolatey and Winget
- Matches installed packages against config module manifests (YAML) to show which apps have managed configs
- Categorizes apps as Managed, Detected (installed but no config module), or Missing (in manifest but not installed)

## Test plan
- [ ] `dotnet test` passes all new unit tests (manifest parsing, choco/winget providers, scan service)
- [ ] `dotnet run --project src/Perch.Cli -- apps` shows correct output on a machine with choco/winget
- [ ] Verify CI passes on Linux (graceful handling when package managers aren't available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)