### PR TITLE
Fix await ordering in DefaultProcessRunner

### DIFF
--- a/src/Perch.Core/Packages/DefaultProcessRunner.cs
+++ b/src/Perch.Core/Packages/DefaultProcessRunner.cs
@@ -24,11 +24,9 @@ public sealed class DefaultProcessRunner : IProcessRunner
         var stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
         var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
 
+        await Task.WhenAll(stdoutTask, stderrTask).ConfigureAwait(false);
         await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
 
-        string stdout = await stdoutTask.ConfigureAwait(false);
-        string stderr = await stderrTask.ConfigureAwait(false);
-
-        return new ProcessRunResult(process.ExitCode, stdout, stderr);
+        return new ProcessRunResult(process.ExitCode, stdoutTask.Result, stderrTask.Result);
     }
 }


### PR DESCRIPTION
## Summary
- Reorder awaits in `DefaultProcessRunner.RunAsync`: read stdout/stderr before `WaitForExitAsync`
- Prevents orphaned read tasks on cancellation and avoids potential buffer-full deadlocks
- Follows [Microsoft's recommended pattern](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.standardoutput#remarks)

## Test plan
- [ ] Existing tests pass (`dotnet test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)