### PR TITLE
Move package manager DI to Windows platform check

### DIFF
--- a/src/Perch.Core/ServiceCollectionExtensions.cs
+++ b/src/Perch.Core/ServiceCollectionExtensions.cs
@@ -26,6 +26,8 @@ public static class ServiceCollectionExtensions
             services.AddSingleton<ISymlinkProvider, WindowsSymlinkProvider>();
             services.AddSingleton<IFileLockDetector, WindowsFileLockDetector>();
             services.AddSingleton<IRegistryProvider, WindowsRegistryProvider>();
+            services.AddSingleton<IPackageManagerProvider, ChocolateyPackageManagerProvider>();
+            services.AddSingleton<IPackageManagerProvider, WingetPackageManagerProvider>();
         }
         else
         {
@@ -45,8 +47,6 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ISettingsProvider, YamlSettingsProvider>();
         services.AddSingleton<PackageManifestParser>();
         services.AddSingleton<IProcessRunner, DefaultProcessRunner>();
-        services.AddSingleton<IPackageManagerProvider, ChocolateyPackageManagerProvider>();
-        services.AddSingleton<IPackageManagerProvider, WingetPackageManagerProvider>();
         services.AddSingleton<IAppScanService, AppScanService>();
         return services;
     }


### PR DESCRIPTION
## Summary
- Move `ChocolateyPackageManagerProvider` and `WingetPackageManagerProvider` registrations inside the existing `if (OperatingSystem.IsWindows())` block
- These package managers only exist on Windows — registering them unconditionally produces spurious warnings on Linux CI
- Consistent with the existing pattern for `WindowsSymlinkProvider`/`WindowsFileLockDetector`

## Test plan
- [ ] `dotnet test` passes
- [ ] On Linux CI: no more "chocolatey/winget is not installed" warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)