### PR TITLE
Narrow YAML catch to YamlException

### DIFF
--- a/src/Perch.Core/Packages/PackageManifestParser.cs
+++ b/src/Perch.Core/Packages/PackageManifestParser.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using YamlDotNet.Core;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -23,7 +24,7 @@ public sealed class PackageManifestParser
         {
             model = Deserializer.Deserialize<PackageYamlModel>(yaml);
         }
-        catch (Exception ex)
+        catch (YamlException ex)
         {
             return PackageManifestParseResult.Failure($"Invalid YAML: {ex.Message}");
         }


### PR DESCRIPTION
## Summary
- Replace `catch (Exception)` with `catch (YamlException)` in `PackageManifestParser.Parse`
- Avoids accidentally swallowing non-YAML errors (e.g., `OutOfMemoryException`)
- Per style guide: don't catch `Exception` at low levels

## Test plan
- [ ] All `PackageManifestParserTests` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)