### PR TITLE
Fix path separator handling for Linux CI

### DIFF
--- a/src/Perch.Core/Modules/GlobResolver.cs
+++ b/src/Perch.Core/Modules/GlobResolver.cs
@@ -9,8 +9,13 @@ public sealed class GlobResolver : IGlobResolver
             return [path];
         }
 
-        string[] segments = path.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        var current = new List<string> { "" };
+        string root = Path.GetPathRoot(path) ?? "";
+        string relativePart = path[root.Length..];
+        string[] segments = relativePart
+            .Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            .Where(s => s.Length > 0)
+            .ToArray();
+        var current = new List<string> { root };
 
         for (int i = 0; i < segments.Length; i++)
         {

--- a/tests/Perch.Core.Tests/Deploy/DeployServiceTests.cs
+++ b/tests/Perch.Core.Tests/Deploy/DeployServiceTests.cs
@@ -161,7 +161,7 @@ public sealed class DeployServiceTests
         {
             var modules = ImmutableArray.Create(
                 new AppModule("mod", "Module", true, modulePath, ImmutableArray<Platform>.Empty, ImmutableArray.Create(
-                    new LinkEntry("file.txt", "%PERCH_TEST_DEPLOY%\\output.txt", LinkType.Symlink))));
+                    new LinkEntry("file.txt", $"%PERCH_TEST_DEPLOY%{Path.DirectorySeparatorChar}output.txt", LinkType.Symlink))));
             _discoveryService.DiscoverAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns(new DiscoveryResult(modules, ImmutableArray<string>.Empty));
 


### PR DESCRIPTION
## Summary
- Fix GlobResolver losing path root on Linux (splitting `/tmp/foo` produced relative `tmp/foo`)
- Fix deploy test hardcoding backslash separator that fails on Linux

## Test Plan
- [ ] CI passes on both ubuntu-latest and windows-latest