### PR TITLE
Add Open Location button for app config folders and dotfile paths

### DIFF
--- a/src/Perch.Desktop/Models/AppCardModel.cs
+++ b/src/Perch.Desktop/Models/AppCardModel.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 
 using CommunityToolkit.Mvvm.ComponentModel;
 
+using Perch.Core;
 using Perch.Core.Catalog;
 
 namespace Perch.Desktop.Models;
@@ -49,6 +50,11 @@ public partial class AppCardModel : ObservableObject
     public ImmutableArray<AppCardModel> DependentApps { get; set; } = [];
     public bool HasDependents => !DependentApps.IsDefaultOrEmpty;
     public int DependentAppCount => DependentApps.IsDefaultOrEmpty ? 0 : DependentApps.Length;
+
+    public string? ConfigPath => Config?.Links
+        .Where(l => l.Targets.ContainsKey(Platform.Windows))
+        .Select(l => Environment.ExpandEnvironmentVariables(l.Targets[Platform.Windows].Replace('/', '\\')))
+        .FirstOrDefault();
 
     public string DisplayLabel => DisplayName ?? Name;
     public string BroadCategory => Category.Split('/')[0];

--- a/src/Perch.Desktop/Views/Controls/AppCard.xaml
+++ b/src/Perch.Desktop/Views/Controls/AppCard.xaml
@@ -205,6 +205,19 @@
                             Visibility="{Binding GitHubStarsFormatted, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource CountToVisibilityConverter}}" />
                     </StackPanel>
                 </Button>
+                <Button
+                    Background="Transparent"
+                    BorderThickness="0"
+                    Padding="4,2"
+                    Click="OnOpenLocationClick"
+                    Tag="{Binding ConfigPath, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                    ToolTip="{Binding ConfigPath, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                    Visibility="{Binding ConfigPath, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource CountToVisibilityConverter}}">
+                    <StackPanel Orientation="Horizontal">
+                        <ui:SymbolIcon Symbol="FolderOpen24" FontSize="12" Foreground="#6B7280" />
+                        <TextBlock Text="Open Location" FontSize="10" Foreground="#6B7280" Margin="4,0,0,0" VerticalAlignment="Center" />
+                    </StackPanel>
+                </Button>
             </StackPanel>
 
             <!-- Row 4: Tag pills -->

--- a/src/Perch.Desktop/Views/Controls/AppCard.xaml.cs
+++ b/src/Perch.Desktop/Views/Controls/AppCard.xaml.cs
@@ -75,6 +75,10 @@ public partial class AppCard : UserControl
         DependencyProperty.Register(nameof(IsTopPick), typeof(bool), typeof(AppCard),
             new PropertyMetadata(false));
 
+    public static readonly DependencyProperty ConfigPathProperty =
+        DependencyProperty.Register(nameof(ConfigPath), typeof(string), typeof(AppCard),
+            new PropertyMetadata(null));
+
     public static readonly DependencyProperty TagsProperty =
         DependencyProperty.Register(nameof(Tags), typeof(ImmutableArray<string>), typeof(AppCard),
             new PropertyMetadata(ImmutableArray<string>.Empty));
@@ -183,6 +187,12 @@ public partial class AppCard : UserControl
         set => SetValue(IsTopPickProperty, value);
     }
 
+    public string? ConfigPath
+    {
+        get => (string?)GetValue(ConfigPathProperty);
+        set => SetValue(ConfigPathProperty, value);
+    }
+
     public ImmutableArray<string> Tags
     {
         get => (ImmutableArray<string>)GetValue(TagsProperty);
@@ -262,6 +272,17 @@ public partial class AppCard : UserControl
     {
         if (sender is FrameworkElement { Tag: string url } && !string.IsNullOrEmpty(url))
             Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+    }
+
+    private void OnOpenLocationClick(object sender, RoutedEventArgs e)
+    {
+        if (sender is FrameworkElement { Tag: string path } && !string.IsNullOrEmpty(path))
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = "explorer.exe",
+                Arguments = $"/select,\"{path}\"",
+                UseShellExecute = true,
+            });
     }
 
     private void OnTagClick(object sender, MouseButtonEventArgs e) =>

--- a/src/Perch.Desktop/Views/Pages/AppsPage.xaml
+++ b/src/Perch.Desktop/Views/Pages/AppsPage.xaml
@@ -238,6 +238,7 @@
                                                             Website="{Binding Website}"
                                                             Docs="{Binding Docs}"
                                                             GitHub="{Binding GitHub}"
+                                                            ConfigPath="{Binding ConfigPath}"
                                                             License="{Binding License}"
                                                             IsManaged="{Binding IsManaged}"
                                                             CanToggle="{Binding CanToggle}"

--- a/src/Perch.Desktop/Views/Pages/DotfilesPage.xaml
+++ b/src/Perch.Desktop/Views/Pages/DotfilesPage.xaml
@@ -244,6 +244,7 @@
                                                 <ColumnDefinition Width="Auto" />
                                                 <ColumnDefinition Width="Auto" />
                                                 <ColumnDefinition Width="*" />
+                                                <ColumnDefinition Width="Auto" />
                                             </Grid.ColumnDefinitions>
                                             <ui:SymbolIcon
                                                 Grid.Column="0"
@@ -269,6 +270,18 @@
                                             <TextBlock Grid.Column="1" Text="{Binding FileName}" FontSize="11" Foreground="White" Margin="0,0,8,0" />
                                             <TextBlock Grid.Column="2" Text="{Binding FullPath}" FontSize="10" Foreground="#666666"
                                                        TextTrimming="CharacterEllipsis" ToolTip="{Binding FullPath}" />
+                                            <Button
+                                                Grid.Column="3"
+                                                Background="Transparent"
+                                                BorderThickness="0"
+                                                Padding="4,2"
+                                                Margin="4,0,0,0"
+                                                Click="OnOpenFileLocationClick"
+                                                Tag="{Binding FullPath}"
+                                                ToolTip="Open in Explorer"
+                                                Visibility="{Binding Exists, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                <ui:SymbolIcon Symbol="FolderOpen24" FontSize="12" Foreground="#6B7280" />
+                                            </Button>
                                         </Grid>
                                     </DataTemplate>
                                 </ItemsControl.ItemTemplate>

--- a/src/Perch.Desktop/Views/Pages/DotfilesPage.xaml.cs
+++ b/src/Perch.Desktop/Views/Pages/DotfilesPage.xaml.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -20,5 +21,16 @@ public partial class DotfilesPage : Page
     {
         if (ViewModel.RefreshCommand.CanExecute(null))
             ViewModel.RefreshCommand.Execute(null);
+    }
+
+    private void OnOpenFileLocationClick(object sender, RoutedEventArgs e)
+    {
+        if (sender is FrameworkElement { Tag: string path } && !string.IsNullOrEmpty(path))
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = "explorer.exe",
+                Arguments = $"/select,\"{path}\"",
+                UseShellExecute = true,
+            });
     }
 }


### PR DESCRIPTION
## Summary
- Add "Open Location" button on AppCard (links bar) that opens Explorer at the app's config folder, visible only when the app has Windows config links
- Add folder icon button per file row in the Dotfiles detail view, visible only when the file exists on disk
- Both use `explorer.exe /select,"path"` pattern consistent with existing FontCard Open Location

## Test Plan
- [x] `dotnet build` -- zero warnings
- [x] `dotnet test` -- all 1097 core tests pass
- [x] Smoke tests -- all 5 page screenshots pass
- [ ] Manual: expand an app with config links (e.g. VS Code) -- "Open Location" button appears and opens Explorer
- [ ] Manual: open a dotfile detail view with existing files -- folder icon appears per file row and opens Explorer

Closes #64