### PR TITLE
Add read-only certificate store manager to Windows Tweaks

### DIFF
--- a/src/Perch.Core/Scanner/CertificateScanner.cs
+++ b/src/Perch.Core/Scanner/CertificateScanner.cs
@@ -1,0 +1,61 @@
+using System.Collections.Immutable;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Perch.Core.Scanner;
+
+public sealed class CertificateScanner : ICertificateScanner
+{
+    private static readonly (StoreName Name, CertificateStoreName Mapped)[] Stores =
+    [
+        (StoreName.My, CertificateStoreName.Personal),
+        (StoreName.Root, CertificateStoreName.TrustedRoot),
+        (StoreName.CertificateAuthority, CertificateStoreName.Intermediate),
+        (StoreName.TrustedPeople, CertificateStoreName.TrustedPeople),
+    ];
+
+    public Task<ImmutableArray<DetectedCertificate>> ScanAsync(CancellationToken cancellationToken = default)
+    {
+        var results = new List<DetectedCertificate>();
+
+        foreach (var (storeName, mapped) in Stores)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ScanStore(storeName, mapped, results);
+        }
+
+        return Task.FromResult(results.ToImmutableArray());
+    }
+
+    private static void ScanStore(StoreName storeName, CertificateStoreName mapped, List<DetectedCertificate> results)
+    {
+        try
+        {
+            using var store = new X509Store(storeName, StoreLocation.CurrentUser);
+            store.Open(OpenFlags.ReadOnly | OpenFlags.OpenExistingOnly);
+
+            foreach (var cert in store.Certificates)
+            {
+                try
+                {
+                    results.Add(new DetectedCertificate(
+                        cert.Thumbprint,
+                        cert.Subject,
+                        cert.Issuer,
+                        string.IsNullOrWhiteSpace(cert.FriendlyName) ? null : cert.FriendlyName,
+                        cert.NotBefore,
+                        cert.NotAfter,
+                        cert.HasPrivateKey,
+                        mapped));
+                }
+                finally
+                {
+                    cert.Dispose();
+                }
+            }
+        }
+        catch (Exception) when (storeName != StoreName.Root)
+        {
+            // Non-critical store access failure -- Root should always exist
+        }
+    }
+}

--- a/src/Perch.Core/Scanner/DetectedCertificate.cs
+++ b/src/Perch.Core/Scanner/DetectedCertificate.cs
@@ -1,0 +1,19 @@
+namespace Perch.Core.Scanner;
+
+public enum CertificateStoreName
+{
+    Personal,
+    TrustedRoot,
+    Intermediate,
+    TrustedPeople,
+}
+
+public sealed record DetectedCertificate(
+    string Thumbprint,
+    string Subject,
+    string Issuer,
+    string? FriendlyName,
+    DateTime NotBefore,
+    DateTime NotAfter,
+    bool HasPrivateKey,
+    CertificateStoreName Store);

--- a/src/Perch.Core/Scanner/ICertificateScanner.cs
+++ b/src/Perch.Core/Scanner/ICertificateScanner.cs
@@ -1,0 +1,8 @@
+using System.Collections.Immutable;
+
+namespace Perch.Core.Scanner;
+
+public interface ICertificateScanner
+{
+    Task<ImmutableArray<DetectedCertificate>> ScanAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Perch.Core/ServiceCollectionExtensions.cs
+++ b/src/Perch.Core/ServiceCollectionExtensions.cs
@@ -94,6 +94,7 @@ public static class ServiceCollectionExtensions
         });
         services.AddSingleton<ICatalogService, CatalogService>();
         services.AddSingleton<IGalleryOverlayService, GalleryOverlayService>();
+        services.AddSingleton<ICertificateScanner, CertificateScanner>();
         services.AddSingleton<IFontScanner, FontScanner>();
         services.AddSingleton<IFontOnboardingService, FontOnboardingService>();
         services.AddSingleton<IVsCodeService, VsCodeService>();

--- a/src/Perch.Desktop/Models/CertificateCardModel.cs
+++ b/src/Perch.Desktop/Models/CertificateCardModel.cs
@@ -1,0 +1,71 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+using Perch.Core.Scanner;
+
+namespace Perch.Desktop.Models;
+
+public enum CertificateExpiryStatus
+{
+    Valid,
+    ExpiringSoon,
+    Expired,
+}
+
+public partial class CertificateCardModel : ObservableObject
+{
+    public DetectedCertificate Certificate { get; }
+    public string SubjectDisplayName { get; }
+    public string IssuerDisplayName { get; }
+    public CertificateExpiryStatus ExpiryStatus { get; }
+
+    [ObservableProperty]
+    private bool _isExpanded;
+
+    public CertificateCardModel(DetectedCertificate certificate)
+        : this(certificate, DateTime.Now)
+    {
+    }
+
+    internal CertificateCardModel(DetectedCertificate certificate, DateTime now)
+    {
+        Certificate = certificate;
+        SubjectDisplayName = ExtractCn(certificate.Subject);
+        IssuerDisplayName = ExtractCn(certificate.Issuer);
+        ExpiryStatus = ComputeExpiryStatus(certificate, now);
+    }
+
+    public bool MatchesSearch(string query)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+            return true;
+
+        return Certificate.Thumbprint.Contains(query, StringComparison.OrdinalIgnoreCase)
+            || Certificate.Subject.Contains(query, StringComparison.OrdinalIgnoreCase)
+            || Certificate.Issuer.Contains(query, StringComparison.OrdinalIgnoreCase)
+            || SubjectDisplayName.Contains(query, StringComparison.OrdinalIgnoreCase)
+            || (Certificate.FriendlyName?.Contains(query, StringComparison.OrdinalIgnoreCase) ?? false);
+    }
+
+    internal static string ExtractCn(string distinguishedName)
+    {
+        const string prefix = "CN=";
+        var idx = distinguishedName.IndexOf(prefix, StringComparison.OrdinalIgnoreCase);
+        if (idx < 0)
+            return distinguishedName;
+
+        var start = idx + prefix.Length;
+        var end = distinguishedName.IndexOf(',', start);
+        return end < 0 ? distinguishedName[start..] : distinguishedName[start..end];
+    }
+
+    private static CertificateExpiryStatus ComputeExpiryStatus(DetectedCertificate cert, DateTime now)
+    {
+        if (now > cert.NotAfter)
+            return CertificateExpiryStatus.Expired;
+
+        if ((cert.NotAfter - now).TotalDays < 30)
+            return CertificateExpiryStatus.ExpiringSoon;
+
+        return CertificateExpiryStatus.Valid;
+    }
+}

--- a/src/Perch.Desktop/Models/CertificateStoreGroupModel.cs
+++ b/src/Perch.Desktop/Models/CertificateStoreGroupModel.cs
@@ -1,0 +1,40 @@
+using System.Collections.ObjectModel;
+
+using CommunityToolkit.Mvvm.ComponentModel;
+
+using Perch.Core.Scanner;
+
+namespace Perch.Desktop.Models;
+
+public partial class CertificateStoreGroupModel : ObservableObject
+{
+    public CertificateStoreName Store { get; }
+    public string DisplayName { get; }
+    public ObservableCollection<CertificateCardModel> Certificates { get; }
+
+    [ObservableProperty]
+    private bool _isExpanded = true;
+
+    public CertificateStoreGroupModel(CertificateStoreName store, IEnumerable<CertificateCardModel> certificates)
+    {
+        Store = store;
+        DisplayName = store switch
+        {
+            CertificateStoreName.Personal => "Personal",
+            CertificateStoreName.TrustedRoot => "Trusted Root CAs",
+            CertificateStoreName.Intermediate => "Intermediate CAs",
+            CertificateStoreName.TrustedPeople => "Trusted People",
+            _ => store.ToString(),
+        };
+        Certificates = new ObservableCollection<CertificateCardModel>(certificates);
+    }
+
+    public bool MatchesSearch(string query)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+            return true;
+
+        return DisplayName.Contains(query, StringComparison.OrdinalIgnoreCase)
+            || Certificates.Any(c => c.MatchesSearch(query));
+    }
+}

--- a/src/Perch.Desktop/Models/TweakCategoryCardModel.cs
+++ b/src/Perch.Desktop/Models/TweakCategoryCardModel.cs
@@ -42,6 +42,7 @@ public partial class TweakCategoryCardModel : ObservableObject
         "Performance" => SymbolRegular.TopSpeed24,
         "Input" => SymbolRegular.Keyboard24,
         "Appearance" => SymbolRegular.PaintBrush24,
+        "Certificates" => SymbolRegular.ShieldLock24,
         _ => SymbolRegular.Wrench24,
     };
 }

--- a/src/Perch.Desktop/Views/Pages/SystemTweaksPage.xaml
+++ b/src/Perch.Desktop/Views/Pages/SystemTweaksPage.xaml
@@ -576,6 +576,222 @@
                 </ScrollViewer>
             </Grid>
 
+            <!-- Certificate cards for Certificates category -->
+            <Grid Grid.Row="1" x:Name="CertificateDetailPanel" Visibility="Collapsed">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+
+                <ui:TextBox
+                    Grid.Row="0"
+                    PlaceholderText="Filter certificates..."
+                    Text="{Binding CertificateSearchText, UpdateSourceTrigger=PropertyChanged}"
+                    Width="250"
+                    Margin="0,0,0,12" />
+
+                <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
+                    <ItemsControl ItemsSource="{Binding FilteredCertificateGroups}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate DataType="{x:Type models:CertificateStoreGroupModel}">
+                                <Border
+                                    Background="#1A1A2E"
+                                    BorderBrush="#333350"
+                                    BorderThickness="1"
+                                    CornerRadius="8"
+                                    Padding="12"
+                                    Margin="0,0,0,8">
+                                    <StackPanel>
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto" />
+                                                <ColumnDefinition Width="*" />
+                                                <ColumnDefinition Width="Auto" />
+                                            </Grid.ColumnDefinitions>
+
+                                            <ui:Button
+                                                Grid.Column="0"
+                                                Content="{Binding IsExpanded, Converter={StaticResource BooleanToChevronConverter}}"
+                                                Padding="2"
+                                                Height="22"
+                                                Width="22"
+                                                Margin="0,0,8,0"
+                                                VerticalAlignment="Center"
+                                                Click="OnCertificateGroupExpandClick" />
+
+                                            <TextBlock
+                                                Grid.Column="1"
+                                                Text="{Binding DisplayName}"
+                                                FontSize="14"
+                                                FontWeight="SemiBold"
+                                                Foreground="White"
+                                                VerticalAlignment="Center" />
+
+                                            <TextBlock
+                                                Grid.Column="2"
+                                                FontSize="11"
+                                                Foreground="#666666"
+                                                VerticalAlignment="Center">
+                                                <Run Text="{Binding Certificates.Count, Mode=OneWay}" />
+                                                <Run Text=" certificates" />
+                                            </TextBlock>
+                                        </Grid>
+
+                                        <ItemsControl
+                                            ItemsSource="{Binding Certificates}"
+                                            Margin="24,8,0,0"
+                                            Visibility="{Binding IsExpanded, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate DataType="{x:Type models:CertificateCardModel}">
+                                                    <Border
+                                                        Background="#12122A"
+                                                        BorderBrush="#333350"
+                                                        BorderThickness="1"
+                                                        CornerRadius="6"
+                                                        Padding="10"
+                                                        Margin="0,0,0,6">
+                                                        <Grid>
+                                                            <Grid.RowDefinitions>
+                                                                <RowDefinition Height="Auto" />
+                                                                <RowDefinition Height="Auto" />
+                                                                <RowDefinition Height="Auto" />
+                                                            </Grid.RowDefinitions>
+
+                                                            <Grid Grid.Row="0">
+                                                                <Grid.ColumnDefinitions>
+                                                                    <ColumnDefinition Width="*" />
+                                                                    <ColumnDefinition Width="Auto" />
+                                                                </Grid.ColumnDefinitions>
+
+                                                                <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                                                                    <TextBlock
+                                                                        Text="{Binding SubjectDisplayName}"
+                                                                        FontSize="13"
+                                                                        FontWeight="SemiBold"
+                                                                        Foreground="White"
+                                                                        TextTrimming="CharacterEllipsis"
+                                                                        ToolTip="{Binding Certificate.Subject}" />
+                                                                    <TextBlock
+                                                                        FontSize="11"
+                                                                        Foreground="#888888"
+                                                                        TextTrimming="CharacterEllipsis"
+                                                                        Margin="0,2,0,0">
+                                                                        <Run Text="Issuer: " /><Run Text="{Binding IssuerDisplayName, Mode=OneWay}" />
+                                                                    </TextBlock>
+                                                                </StackPanel>
+
+                                                                <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
+                                                                    <Border
+                                                                        CornerRadius="4"
+                                                                        Padding="6,2"
+                                                                        Margin="8,0,0,0">
+                                                                        <Border.Style>
+                                                                            <Style TargetType="Border">
+                                                                                <Setter Property="Background" Value="#1A3D2E" />
+                                                                                <Style.Triggers>
+                                                                                    <DataTrigger Binding="{Binding ExpiryStatus}" Value="ExpiringSoon">
+                                                                                        <Setter Property="Background" Value="#3D3A1A" />
+                                                                                    </DataTrigger>
+                                                                                    <DataTrigger Binding="{Binding ExpiryStatus}" Value="Expired">
+                                                                                        <Setter Property="Background" Value="#3D1A1A" />
+                                                                                    </DataTrigger>
+                                                                                </Style.Triggers>
+                                                                            </Style>
+                                                                        </Border.Style>
+                                                                        <TextBlock FontSize="10">
+                                                                            <TextBlock.Style>
+                                                                                <Style TargetType="TextBlock">
+                                                                                    <Setter Property="Foreground" Value="#10B981" />
+                                                                                    <Setter Property="Text" Value="Valid" />
+                                                                                    <Style.Triggers>
+                                                                                        <DataTrigger Binding="{Binding ExpiryStatus}" Value="ExpiringSoon">
+                                                                                            <Setter Property="Foreground" Value="#EAB308" />
+                                                                                            <Setter Property="Text" Value="Expiring soon" />
+                                                                                        </DataTrigger>
+                                                                                        <DataTrigger Binding="{Binding ExpiryStatus}" Value="Expired">
+                                                                                            <Setter Property="Foreground" Value="#EF4444" />
+                                                                                            <Setter Property="Text" Value="Expired" />
+                                                                                        </DataTrigger>
+                                                                                    </Style.Triggers>
+                                                                                </Style>
+                                                                            </TextBlock.Style>
+                                                                        </TextBlock>
+                                                                    </Border>
+                                                                    <ui:Button
+                                                                        Content="{Binding IsExpanded, Converter={StaticResource BooleanToChevronConverter}}"
+                                                                        Padding="2"
+                                                                        Height="22"
+                                                                        Width="22"
+                                                                        Margin="4,0,0,0"
+                                                                        VerticalAlignment="Center"
+                                                                        Click="OnCertificateExpandClick" />
+                                                                </StackPanel>
+                                                            </Grid>
+
+                                                            <TextBlock
+                                                                Grid.Row="1"
+                                                                FontSize="11"
+                                                                Foreground="#666666"
+                                                                Margin="0,2,0,0">
+                                                                <Run Text="Expires: " /><Run Text="{Binding Certificate.NotAfter, Mode=OneWay, StringFormat=d}" />
+                                                            </TextBlock>
+
+                                                            <StackPanel
+                                                                Grid.Row="2"
+                                                                Margin="0,6,0,0"
+                                                                Visibility="{Binding IsExpanded, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                                <Border
+                                                                    Background="#0D0D1A"
+                                                                    CornerRadius="4"
+                                                                    Padding="8">
+                                                                    <StackPanel>
+                                                                        <TextBlock FontSize="10" Foreground="#666666" Margin="0,0,0,2">
+                                                                            <Run Text="Thumbprint: " />
+                                                                        </TextBlock>
+                                                                        <TextBlock
+                                                                            Text="{Binding Certificate.Thumbprint}"
+                                                                            FontSize="10"
+                                                                            FontFamily="Cascadia Code,Consolas,Courier New"
+                                                                            Foreground="#888888"
+                                                                            TextWrapping="Wrap"
+                                                                            Margin="0,0,0,6" />
+
+                                                                        <TextBlock FontSize="10" Foreground="#666666">
+                                                                            <Run Text="Valid: " />
+                                                                            <Run Text="{Binding Certificate.NotBefore, Mode=OneWay, StringFormat=d}" />
+                                                                            <Run Text=" - " />
+                                                                            <Run Text="{Binding Certificate.NotAfter, Mode=OneWay, StringFormat=d}" />
+                                                                        </TextBlock>
+
+                                                                        <TextBlock FontSize="10" Foreground="#666666" Margin="0,2,0,0">
+                                                                            <Run Text="Subject: " /><Run Text="{Binding Certificate.Subject, Mode=OneWay}" />
+                                                                        </TextBlock>
+
+                                                                        <TextBlock FontSize="10" Foreground="#666666" Margin="0,2,0,0"
+                                                                                   Visibility="{Binding Certificate.FriendlyName, Converter={StaticResource CountToVisibilityConverter}}">
+                                                                            <Run Text="Friendly name: " /><Run Text="{Binding Certificate.FriendlyName, Mode=OneWay}" />
+                                                                        </TextBlock>
+
+                                                                        <TextBlock FontSize="10" Foreground="#666666" Margin="0,2,0,0"
+                                                                                   Visibility="{Binding Certificate.HasPrivateKey, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                                            <Run Text="Has private key" />
+                                                                        </TextBlock>
+                                                                    </StackPanel>
+                                                                </Border>
+                                                            </StackPanel>
+                                                        </Grid>
+                                                    </Border>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </ScrollViewer>
+            </Grid>
+
             <!-- Font cards for Fonts category -->
             <Grid Grid.Row="1" x:Name="FontDetailPanel">
                 <Grid.RowDefinitions>

--- a/src/Perch.Desktop/Views/Pages/SystemTweaksPage.xaml.cs
+++ b/src/Perch.Desktop/Views/Pages/SystemTweaksPage.xaml.cs
@@ -79,6 +79,18 @@ public partial class SystemTweaksPage : Page
             group.IsExpanded = !group.IsExpanded;
     }
 
+    private void OnCertificateGroupExpandClick(object sender, RoutedEventArgs e)
+    {
+        if (sender is FrameworkElement { DataContext: CertificateStoreGroupModel group })
+            group.IsExpanded = !group.IsExpanded;
+    }
+
+    private void OnCertificateExpandClick(object sender, RoutedEventArgs e)
+    {
+        if (sender is FrameworkElement { DataContext: CertificateCardModel cert })
+            cert.IsExpanded = !cert.IsExpanded;
+    }
+
     private void OnStartupToggleEnabledClick(object sender, RoutedEventArgs e)
     {
         if (GetStartupCardModel(sender) is { } card)
@@ -97,6 +109,7 @@ public partial class SystemTweaksPage : Page
         var subCategory = ViewModel.SelectedSubCategory;
         var isFonts = string.Equals(category, "Fonts", StringComparison.OrdinalIgnoreCase);
         var isStartup = string.Equals(category, "Startup", StringComparison.OrdinalIgnoreCase);
+        var isCertificates = string.Equals(category, "Certificates", StringComparison.OrdinalIgnoreCase);
         var isSystemTweaks = string.Equals(category, "System Tweaks", StringComparison.OrdinalIgnoreCase);
 
         SubCategoryPanel.Visibility = isSystemTweaks && subCategory is null
@@ -106,6 +119,8 @@ public partial class SystemTweaksPage : Page
         FontDetailPanel.Visibility = isFonts
             ? Visibility.Visible : Visibility.Collapsed;
         StartupDetailPanel.Visibility = isStartup
+            ? Visibility.Visible : Visibility.Collapsed;
+        CertificateDetailPanel.Visibility = isCertificates
             ? Visibility.Visible : Visibility.Collapsed;
 
         UpdateBackButton();

--- a/tests/Perch.Core.Tests/Desktop/CertificateCardModelTests.cs
+++ b/tests/Perch.Core.Tests/Desktop/CertificateCardModelTests.cs
@@ -1,0 +1,122 @@
+#if DESKTOP_TESTS
+using Perch.Core.Scanner;
+using Perch.Desktop.Models;
+
+namespace Perch.Core.Tests.Desktop;
+
+[TestFixture]
+public sealed class CertificateCardModelTests
+{
+    [TestCase("CN=Microsoft Root Authority, OU=Microsoft Corporation, OU=Copyright (c) 1997 Microsoft Corp.", "Microsoft Root Authority")]
+    [TestCase("CN=DigiCert Global Root G2, OU=www.digicert.com, O=DigiCert Inc, C=US", "DigiCert Global Root G2")]
+    [TestCase("O=Some Org, C=US", "O=Some Org, C=US")]
+    [TestCase("CN=Simple", "Simple")]
+    [TestCase("cn=lowercase", "lowercase")]
+    public void ExtractCn_ParsesDistinguishedName(string dn, string expected)
+    {
+        var result = CertificateCardModel.ExtractCn(dn);
+        Assert.That(result, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void ExpiryStatus_Expired_WhenPastNotAfter()
+    {
+        var cert = MakeCert(
+            notBefore: new DateTime(2020, 1, 1),
+            notAfter: new DateTime(2024, 1, 1));
+        var now = new DateTime(2025, 6, 1);
+
+        var model = new CertificateCardModel(cert, now);
+
+        Assert.That(model.ExpiryStatus, Is.EqualTo(CertificateExpiryStatus.Expired));
+    }
+
+    [Test]
+    public void ExpiryStatus_ExpiringSoon_WhenWithin30Days()
+    {
+        var cert = MakeCert(
+            notBefore: new DateTime(2020, 1, 1),
+            notAfter: new DateTime(2025, 7, 1));
+        var now = new DateTime(2025, 6, 15);
+
+        var model = new CertificateCardModel(cert, now);
+
+        Assert.That(model.ExpiryStatus, Is.EqualTo(CertificateExpiryStatus.ExpiringSoon));
+    }
+
+    [Test]
+    public void ExpiryStatus_Valid_WhenWellBeforeExpiry()
+    {
+        var cert = MakeCert(
+            notBefore: new DateTime(2020, 1, 1),
+            notAfter: new DateTime(2030, 1, 1));
+        var now = new DateTime(2025, 6, 1);
+
+        var model = new CertificateCardModel(cert, now);
+
+        Assert.That(model.ExpiryStatus, Is.EqualTo(CertificateExpiryStatus.Valid));
+    }
+
+    [TestCase("ABC123", true)]
+    [TestCase("abc123", true)]
+    [TestCase("Microsoft", true)]
+    [TestCase("DigiCert", true)]
+    [TestCase("nonexistent-xyz", false)]
+    public void MatchesSearch_MatchesThumbprintSubjectIssuer(string query, bool expected)
+    {
+        var cert = new DetectedCertificate(
+            Thumbprint: "ABC123DEF456",
+            Subject: "CN=Microsoft Root Authority",
+            Issuer: "CN=DigiCert Global Root",
+            FriendlyName: null,
+            NotBefore: DateTime.MinValue,
+            NotAfter: DateTime.MaxValue,
+            HasPrivateKey: false,
+            Store: CertificateStoreName.TrustedRoot);
+
+        var model = new CertificateCardModel(cert);
+
+        Assert.That(model.MatchesSearch(query), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void MatchesSearch_MatchesFriendlyName()
+    {
+        var cert = MakeCert(friendlyName: "My Test Certificate");
+        var model = new CertificateCardModel(cert);
+
+        Assert.That(model.MatchesSearch("Test Cert"), Is.True);
+    }
+
+    [Test]
+    public void MatchesSearch_EmptyQuery_ReturnsTrue()
+    {
+        var cert = MakeCert();
+        var model = new CertificateCardModel(cert);
+
+        Assert.That(model.MatchesSearch(""), Is.True);
+        Assert.That(model.MatchesSearch("  "), Is.True);
+    }
+
+    private static DetectedCertificate MakeCert(
+        string thumbprint = "AABB",
+        string subject = "CN=Test",
+        string issuer = "CN=Issuer",
+        string? friendlyName = null,
+        DateTime? notBefore = null,
+        DateTime? notAfter = null,
+        bool hasPrivateKey = false,
+        CertificateStoreName store = CertificateStoreName.TrustedRoot)
+    {
+        return new DetectedCertificate(
+            thumbprint,
+            subject,
+            issuer,
+            friendlyName,
+            notBefore ?? DateTime.MinValue,
+            notAfter ?? DateTime.MaxValue,
+            hasPrivateKey,
+            store);
+    }
+}
+#endif

--- a/tests/Perch.Core.Tests/Desktop/ViewModelTests.cs
+++ b/tests/Perch.Core.Tests/Desktop/ViewModelTests.cs
@@ -9,6 +9,7 @@ using Perch.Core.Catalog;
 using Perch.Core.Config;
 using Perch.Core.Modules;
 using Perch.Core.Registry;
+using Perch.Core.Scanner;
 using Perch.Core.Startup;
 using Perch.Core.Tweaks;
 using Perch.Desktop.Models;
@@ -500,6 +501,7 @@ public sealed class SystemTweaksViewModelTests
     private ISettingsProvider _settingsProvider = null!;
     private IStartupService _startupService = null!;
     private ITweakService _tweakService = null!;
+    private ICertificateScanner _certificateScanner = null!;
     private IPendingChangesService _pendingChanges = null!;
     private SystemTweaksViewModel _vm = null!;
 
@@ -510,6 +512,7 @@ public sealed class SystemTweaksViewModelTests
         _settingsProvider = Substitute.For<ISettingsProvider>();
         _startupService = Substitute.For<IStartupService>();
         _tweakService = Substitute.For<ITweakService>();
+        _certificateScanner = Substitute.For<ICertificateScanner>();
         _pendingChanges = Substitute.For<IPendingChangesService>();
 
         _settingsProvider.LoadAsync(Arg.Any<CancellationToken>())
@@ -523,8 +526,10 @@ public sealed class SystemTweaksViewModelTests
                 ImmutableArray<FontCardModel>.Empty));
         _startupService.GetAllAsync(Arg.Any<CancellationToken>())
             .Returns(Array.Empty<StartupEntry>());
+        _certificateScanner.ScanAsync(Arg.Any<CancellationToken>())
+            .Returns(ImmutableArray<DetectedCertificate>.Empty);
 
-        _vm = new SystemTweaksViewModel(_detectionService, _settingsProvider, _startupService, _tweakService, _pendingChanges);
+        _vm = new SystemTweaksViewModel(_detectionService, _settingsProvider, _startupService, _tweakService, _certificateScanner, _pendingChanges);
     }
 
     [Test]

--- a/tests/Perch.Core.Tests/Scanner/CertificateScannerTests.cs
+++ b/tests/Perch.Core.Tests/Scanner/CertificateScannerTests.cs
@@ -1,0 +1,45 @@
+using Perch.Core.Scanner;
+
+namespace Perch.Core.Tests.Scanner;
+
+[TestFixture]
+public sealed class CertificateScannerTests
+{
+    [Test]
+    public async Task ScanAsync_ReturnsCertificates_FromTrustedRootStore()
+    {
+        var scanner = new CertificateScanner();
+
+        var result = await scanner.ScanAsync();
+
+        var rootCerts = result.Where(c => c.Store == CertificateStoreName.TrustedRoot).ToList();
+        Assert.That(rootCerts, Is.Not.Empty);
+    }
+
+    [Test]
+    public async Task ScanAsync_CertificatesHaveRequiredFields()
+    {
+        var scanner = new CertificateScanner();
+
+        var result = await scanner.ScanAsync();
+
+        Assert.That(result, Is.Not.Empty);
+        foreach (var cert in result.Take(5))
+        {
+            Assert.That(cert.Thumbprint, Is.Not.Null.And.Not.Empty);
+            Assert.That(cert.Subject, Is.Not.Null.And.Not.Empty);
+            Assert.That(cert.Issuer, Is.Not.Null.And.Not.Empty);
+        }
+    }
+
+    [Test]
+    public void ScanAsync_SupportsCancellation()
+    {
+        var scanner = new CertificateScanner();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Assert.ThrowsAsync<OperationCanceledException>(
+            () => scanner.ScanAsync(cts.Token));
+    }
+}


### PR DESCRIPTION
## Summary
- Scan CurrentUser certificate stores (Personal, Trusted Root, Intermediate, Trusted People) and display grouped by store on the Windows Tweaks page
- Certificates show subject CN, issuer, expiry date with color-coded status badges (green valid, yellow expiring soon, red expired)
- Expandable detail per cert: thumbprint (monospace), validity dates, full subject DN, private key indicator
- Search/filter across thumbprint, subject, issuer, and friendly name
- Phase 1 is read-only; import/remove/tracking deferred to future PRs

Closes #55

## Test Plan
- [x] `dotnet build Perch.slnx` -- zero warnings
- [x] `dotnet test tests/Perch.Core.Tests` -- 1115 pass (18 new certificate tests)
- [x] Smoke test screenshot shows Certificates category card with shield icon
- [ ] Launch dev app, navigate to Windows Tweaks > Certificates, verify store groups render with cert cards
- [ ] Verify search filters certificates across all fields
- [ ] Verify expand/collapse works for both store groups and individual cert details