### PR TITLE
Add captured registry value model for pre-Perch state tracking

### DIFF
--- a/src/Perch.Cli/Commands/TweakRevertCommand.cs
+++ b/src/Perch.Cli/Commands/TweakRevertCommand.cs
@@ -24,6 +24,10 @@ public sealed class TweakRevertCommand : AsyncCommand<TweakRevertCommand.Setting
         [CommandOption("--dry-run")]
         [Description("Show what would be changed without writing")]
         public bool DryRun { get; init; }
+
+        [CommandOption("--to-captured")]
+        [Description("Revert to the captured (pre-Perch) state instead of Windows defaults")]
+        public bool ToCaptured { get; init; }
     }
 
     public TweakRevertCommand(ICatalogService catalog, ITweakService tweakService, IAnsiConsole console)
@@ -52,7 +56,9 @@ public sealed class TweakRevertCommand : AsyncCommand<TweakRevertCommand.Setting
             _console.MarkupLine($"[yellow]Dry run:[/] {tweak.Name.EscapeMarkup()}");
         }
 
-        var result = _tweakService.Revert(tweak, settings.DryRun);
+        TweakOperationResult result = settings.ToCaptured
+            ? await _tweakService.RevertToCapturedAsync(tweak, settings.DryRun, cancellationToken)
+            : _tweakService.Revert(tweak, settings.DryRun);
 
         foreach (var entry in result.Entries)
         {

--- a/src/Perch.Core/Registry/CapturedRegistryData.cs
+++ b/src/Perch.Core/Registry/CapturedRegistryData.cs
@@ -1,0 +1,21 @@
+using YamlDotNet.Serialization;
+
+namespace Perch.Core.Registry;
+
+public sealed class CapturedRegistryEntry
+{
+    [YamlMember(Alias = "value")]
+    public string? Value { get; set; }
+
+    [YamlMember(Alias = "kind")]
+    public RegistryValueType Kind { get; set; }
+
+    [YamlMember(Alias = "captured-at")]
+    public DateTime CapturedAt { get; set; }
+}
+
+public sealed class CapturedRegistryData
+{
+    [YamlMember(Alias = "entries")]
+    public Dictionary<string, CapturedRegistryEntry> Entries { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+}

--- a/src/Perch.Core/Registry/ICapturedRegistryStore.cs
+++ b/src/Perch.Core/Registry/ICapturedRegistryStore.cs
@@ -1,0 +1,7 @@
+namespace Perch.Core.Registry;
+
+public interface ICapturedRegistryStore
+{
+    Task<CapturedRegistryData> LoadAsync(CancellationToken cancellationToken = default);
+    Task SaveAsync(CapturedRegistryData data, CancellationToken cancellationToken = default);
+}

--- a/src/Perch.Core/Registry/IThreeValueService.cs
+++ b/src/Perch.Core/Registry/IThreeValueService.cs
@@ -6,5 +6,5 @@ namespace Perch.Core.Registry;
 
 public interface IThreeValueService
 {
-    ImmutableArray<RegistryThreeValueResult> Evaluate(ImmutableArray<RegistryEntryDefinition> entries);
+    ImmutableArray<RegistryThreeValueResult> Evaluate(ImmutableArray<RegistryEntryDefinition> entries, IReadOnlyDictionary<string, string?>? capturedValues = null);
 }

--- a/src/Perch.Core/Registry/RegistryThreeValueResult.cs
+++ b/src/Perch.Core/Registry/RegistryThreeValueResult.cs
@@ -5,4 +5,5 @@ namespace Perch.Core.Registry;
 public sealed record RegistryThreeValueResult(
     RegistryEntryDefinition Entry,
     ThreeValueStatus Status,
-    object? CurrentValue);
+    object? CurrentValue,
+    string? CapturedValue = null);

--- a/src/Perch.Core/Registry/ThreeValueStatus.cs
+++ b/src/Perch.Core/Registry/ThreeValueStatus.cs
@@ -6,5 +6,6 @@ public enum ThreeValueStatus
     Drifted,
     NotApplied,
     Reverted,
+    AtCaptured,
     Error,
 }

--- a/src/Perch.Core/Registry/YamlCapturedRegistryStore.cs
+++ b/src/Perch.Core/Registry/YamlCapturedRegistryStore.cs
@@ -1,0 +1,71 @@
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Perch.Core.Registry;
+
+public sealed class YamlCapturedRegistryStore : ICapturedRegistryStore
+{
+    private readonly string _filePath;
+    private readonly SemaphoreSlim _lock = new(1, 1);
+
+    private static readonly ISerializer Serializer = new SerializerBuilder()
+        .WithNamingConvention(HyphenatedNamingConvention.Instance)
+        .Build();
+
+    private static readonly IDeserializer Deserializer = new DeserializerBuilder()
+        .WithNamingConvention(HyphenatedNamingConvention.Instance)
+        .IgnoreUnmatchedProperties()
+        .Build();
+
+    public YamlCapturedRegistryStore()
+        : this(GetDefaultPath())
+    {
+    }
+
+    internal YamlCapturedRegistryStore(string filePath)
+    {
+        _filePath = filePath;
+    }
+
+    public async Task<CapturedRegistryData> LoadAsync(CancellationToken cancellationToken = default)
+    {
+        await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (!File.Exists(_filePath))
+                return new CapturedRegistryData();
+
+            string yaml = await File.ReadAllTextAsync(_filePath, cancellationToken).ConfigureAwait(false);
+            return Deserializer.Deserialize<CapturedRegistryData>(yaml) ?? new CapturedRegistryData();
+        }
+        catch (Exception)
+        {
+            return new CapturedRegistryData();
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    public async Task SaveAsync(CapturedRegistryData data, CancellationToken cancellationToken = default)
+    {
+        await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            string? directory = Path.GetDirectoryName(_filePath);
+            if (directory != null && !Directory.Exists(directory))
+                Directory.CreateDirectory(directory);
+
+            string yaml = Serializer.Serialize(data);
+            await File.WriteAllTextAsync(_filePath, yaml, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    private static string GetDefaultPath() =>
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "perch", "captured-registry.yaml");
+}

--- a/src/Perch.Core/ServiceCollectionExtensions.cs
+++ b/src/Perch.Core/ServiceCollectionExtensions.cs
@@ -80,6 +80,8 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IContentFilterProcessor, ContentFilterProcessor>();
         services.AddSingleton<IAppScanService, AppScanService>();
         services.AddSingleton<ITweakService, TweakService>();
+        services.AddSingleton<ICapturedRegistryStore, YamlCapturedRegistryStore>();
+        services.AddSingleton<IThreeValueService, ThreeValueService>();
 
         services.AddSingleton<CatalogParser>();
         services.AddSingleton(new System.Net.Http.HttpClient());
@@ -96,6 +98,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IGalleryOverlayService, GalleryOverlayService>();
         services.AddSingleton<IFontScanner, FontScanner>();
         services.AddSingleton<IFontOnboardingService, FontOnboardingService>();
+        services.AddSingleton<FontManifestParser>();
         services.AddSingleton<IVsCodeService, VsCodeService>();
         services.AddSingleton<ISystemScanner, SystemScanner>();
         return services;

--- a/src/Perch.Core/Tweaks/ITweakService.cs
+++ b/src/Perch.Core/Tweaks/ITweakService.cs
@@ -5,6 +5,8 @@ namespace Perch.Core.Tweaks;
 public interface ITweakService
 {
     TweakDetectionResult Detect(TweakCatalogEntry tweak);
+    Task<TweakDetectionResult> DetectWithCaptureAsync(TweakCatalogEntry tweak, CancellationToken cancellationToken = default);
     TweakOperationResult Apply(TweakCatalogEntry tweak, bool dryRun = false);
     TweakOperationResult Revert(TweakCatalogEntry tweak, bool dryRun = false);
+    Task<TweakOperationResult> RevertToCapturedAsync(TweakCatalogEntry tweak, bool dryRun = false, CancellationToken cancellationToken = default);
 }

--- a/src/Perch.Core/Tweaks/TweakDetectionResult.cs
+++ b/src/Perch.Core/Tweaks/TweakDetectionResult.cs
@@ -4,6 +4,6 @@ using Perch.Core.Modules;
 
 namespace Perch.Core.Tweaks;
 
-public sealed record RegistryEntryStatus(RegistryEntryDefinition Definition, object? CurrentValue, bool IsApplied);
+public sealed record RegistryEntryStatus(RegistryEntryDefinition Definition, object? CurrentValue, string? CapturedValue, bool IsApplied);
 
 public sealed record TweakDetectionResult(TweakStatus Status, ImmutableArray<RegistryEntryStatus> Entries);

--- a/src/Perch.Core/Tweaks/TweakService.cs
+++ b/src/Perch.Core/Tweaks/TweakService.cs
@@ -10,10 +10,12 @@ namespace Perch.Core.Tweaks;
 public sealed class TweakService : ITweakService
 {
     private readonly IRegistryProvider _registryProvider;
+    private readonly ICapturedRegistryStore _capturedStore;
 
-    public TweakService(IRegistryProvider registryProvider)
+    public TweakService(IRegistryProvider registryProvider, ICapturedRegistryStore capturedStore)
     {
         _registryProvider = registryProvider;
+        _capturedStore = capturedStore;
     }
 
     public TweakDetectionResult Detect(TweakCatalogEntry tweak)
@@ -35,12 +37,12 @@ public sealed class TweakService : ITweakService
             }
             catch (Exception)
             {
-                entries.Add(new RegistryEntryStatus(entry, null, false));
+                entries.Add(new RegistryEntryStatus(entry, null, null, false));
                 continue;
             }
 
             bool isApplied = Equals(currentValue, entry.Value);
-            entries.Add(new RegistryEntryStatus(entry, currentValue, isApplied));
+            entries.Add(new RegistryEntryStatus(entry, currentValue, null, isApplied));
             if (isApplied) appliedCount++;
         }
 
@@ -51,6 +53,46 @@ public sealed class TweakService : ITweakService
                 : TweakStatus.Partial;
 
         return new TweakDetectionResult(status, entries.MoveToImmutable());
+    }
+
+    public async Task<TweakDetectionResult> DetectWithCaptureAsync(TweakCatalogEntry tweak, CancellationToken cancellationToken = default)
+    {
+        var syncResult = Detect(tweak);
+        if (syncResult.Entries.IsEmpty)
+            return syncResult;
+
+        var capturedData = await _capturedStore.LoadAsync(cancellationToken).ConfigureAwait(false);
+        bool dirty = false;
+
+        var enriched = ImmutableArray.CreateBuilder<RegistryEntryStatus>(syncResult.Entries.Length);
+        foreach (var entry in syncResult.Entries)
+        {
+            string key = $@"{entry.Definition.Key}\{entry.Definition.Name}";
+            string? capturedValue = null;
+
+            if (capturedData.Entries.TryGetValue(key, out var captured))
+            {
+                capturedValue = captured.Value;
+            }
+            else if (entry.CurrentValue != null)
+            {
+                capturedData.Entries[key] = new CapturedRegistryEntry
+                {
+                    Value = entry.CurrentValue.ToString(),
+                    Kind = entry.Definition.Kind,
+                    CapturedAt = DateTime.UtcNow,
+                };
+                capturedValue = entry.CurrentValue.ToString();
+                dirty = true;
+            }
+
+            enriched.Add(entry with { CapturedValue = capturedValue });
+        }
+
+        if (dirty)
+            await _capturedStore.SaveAsync(capturedData, cancellationToken).ConfigureAwait(false);
+
+        return new TweakDetectionResult(syncResult.Status, enriched.MoveToImmutable());
     }
 
     public TweakOperationResult Apply(TweakCatalogEntry tweak, bool dryRun = false)
@@ -130,6 +172,56 @@ public sealed class TweakService : ITweakService
                 _registryProvider.SetValue(entry.Key, entry.Name, entry.DefaultValue, entry.Kind);
                 results.Add(new TweakEntryResult(entry.Key, entry.Name, ResultLevel.Ok,
                     $"Restored {entry.Name} to {entry.DefaultValue}"));
+            }
+            else
+            {
+                _registryProvider.DeleteValue(entry.Key, entry.Name);
+                results.Add(new TweakEntryResult(entry.Key, entry.Name, ResultLevel.Ok,
+                    $"Deleted {entry.Name}"));
+            }
+        }
+
+        return new TweakOperationResult(ResultLevel.Ok, results.MoveToImmutable());
+    }
+
+    public async Task<TweakOperationResult> RevertToCapturedAsync(TweakCatalogEntry tweak, bool dryRun = false, CancellationToken cancellationToken = default)
+    {
+        if (tweak.Registry.IsDefaultOrEmpty)
+            return new TweakOperationResult(ResultLevel.Ok, ImmutableArray<TweakEntryResult>.Empty);
+
+        var capturedData = await _capturedStore.LoadAsync(cancellationToken).ConfigureAwait(false);
+        var results = ImmutableArray.CreateBuilder<TweakEntryResult>(tweak.Registry.Length);
+
+        foreach (RegistryEntryDefinition entry in tweak.Registry)
+        {
+            string capturedKey = $@"{entry.Key}\{entry.Name}";
+            object? targetValue = null;
+            RegistryValueType targetKind = entry.Kind;
+
+            if (capturedData.Entries.TryGetValue(capturedKey, out var captured))
+            {
+                targetValue = captured.Value;
+                targetKind = captured.Kind;
+            }
+            else if (entry.DefaultValue != null)
+            {
+                targetValue = entry.DefaultValue;
+            }
+
+            if (dryRun)
+            {
+                string action = targetValue != null
+                    ? $"Would restore {entry.Name} to {targetValue}"
+                    : $"Would delete {entry.Name}";
+                results.Add(new TweakEntryResult(entry.Key, entry.Name, ResultLevel.Ok, action));
+                continue;
+            }
+
+            if (targetValue != null)
+            {
+                _registryProvider.SetValue(entry.Key, entry.Name, targetValue, targetKind);
+                results.Add(new TweakEntryResult(entry.Key, entry.Name, ResultLevel.Ok,
+                    $"Restored {entry.Name} to {targetValue}"));
             }
             else
             {

--- a/src/Perch.Desktop/Models/TweakCardModel.cs
+++ b/src/Perch.Desktop/Models/TweakCardModel.cs
@@ -42,6 +42,8 @@ public partial class TweakCardModel : ObservableObject
     public bool RestartRequired => Tags.Any(t => string.Equals(t, "restart", StringComparison.OrdinalIgnoreCase));
     public string RegistryKeyCountText => TotalCount == 1 ? "1 registry key" : $"{TotalCount} registry keys";
     public bool IsAllApplied => AppliedCount == TotalCount && TotalCount > 0;
+    public bool HasCapturedValues => !DetectedEntries.IsDefaultOrEmpty
+        && DetectedEntries.Any(e => e.CapturedValue != null);
 
     public TweakCardModel(TweakCatalogEntry entry, CardStatus status)
     {

--- a/src/Perch.Desktop/Services/GalleryDetectionService.cs
+++ b/src/Perch.Desktop/Services/GalleryDetectionService.cs
@@ -208,7 +208,7 @@ public sealed class GalleryDetectionService : IGalleryDetectionService
         {
             try
             {
-                var detection = _tweakService.Detect(tweak);
+                var detection = await _tweakService.DetectWithCaptureAsync(tweak, cancellationToken);
                 CardStatus status = detection.Status switch
                 {
                     TweakStatus.Applied => CardStatus.Detected,

--- a/src/Perch.Desktop/Services/PendingChange.cs
+++ b/src/Perch.Desktop/Services/PendingChange.cs
@@ -8,6 +8,7 @@ public enum PendingChangeKind
     UnlinkApp,
     ApplyTweak,
     RevertTweak,
+    RevertTweakToCaptured,
     LinkDotfile,
     OnboardFont,
     ToggleStartup,
@@ -31,6 +32,9 @@ public sealed record ApplyTweakChange(TweakCardModel Tweak)
 
 public sealed record RevertTweakChange(TweakCardModel Tweak)
     : PendingChange(Tweak.Id, Tweak.Name, Tweak.Description ?? "Revert registry tweak", PendingChangeKind.RevertTweak);
+
+public sealed record RevertTweakToCapturedChange(TweakCardModel Tweak)
+    : PendingChange(Tweak.Id, Tweak.Name, Tweak.Description ?? "Revert tweak to captured state", PendingChangeKind.RevertTweakToCaptured);
 
 public sealed record LinkDotfileChange(DotfileGroupCardModel Dotfile)
     : PendingChange(Dotfile.Id, Dotfile.DisplayLabel, "Link dotfile group", PendingChangeKind.LinkDotfile);

--- a/src/Perch.Desktop/ViewModels/DashboardViewModel.cs
+++ b/src/Perch.Desktop/ViewModels/DashboardViewModel.cs
@@ -229,6 +229,17 @@ public sealed partial class DashboardViewModel : ViewModelBase
             catch (Exception ex) { errors.Add($"Revert tweak: {ex.Message}"); }
         }
 
+        foreach (var change in changes.Where(c => c.Kind == PendingChangeKind.RevertTweakToCaptured))
+        {
+            try
+            {
+                var tweak = ((RevertTweakToCapturedChange)change).Tweak;
+                await _tweakService.RevertToCapturedAsync(tweak.CatalogEntry, cancellationToken: cancellationToken);
+                applied++;
+            }
+            catch (Exception ex) { errors.Add($"Revert to captured: {ex.Message}"); }
+        }
+
         foreach (var change in changes.Where(c => c.Kind == PendingChangeKind.ToggleStartup))
         {
             try
@@ -279,6 +290,7 @@ public sealed partial class DashboardViewModel : ViewModelBase
             UnlinkAppChange c => new LinkAppChange(c.App),
             ApplyTweakChange c => new RevertTweakChange(c.Tweak),
             RevertTweakChange c => new ApplyTweakChange(c.Tweak),
+            RevertTweakToCapturedChange c => new ApplyTweakChange(c.Tweak),
             ToggleStartupChange c => new ToggleStartupChange(c.Startup, !c.Enable),
             _ => change,
         };

--- a/src/Perch.Desktop/ViewModels/SystemTweaksViewModel.cs
+++ b/src/Perch.Desktop/ViewModels/SystemTweaksViewModel.cs
@@ -374,7 +374,16 @@ public sealed partial class SystemTweaksViewModel : ViewModelBase
     private void RevertTweak(TweakCardModel card)
     {
         _pendingChanges.Remove(card.Id, PendingChangeKind.ApplyTweak);
+        _pendingChanges.Remove(card.Id, PendingChangeKind.RevertTweakToCaptured);
         _pendingChanges.Add(new RevertTweakChange(card));
+    }
+
+    [RelayCommand]
+    private void RevertTweakToCaptured(TweakCardModel card)
+    {
+        _pendingChanges.Remove(card.Id, PendingChangeKind.ApplyTweak);
+        _pendingChanges.Remove(card.Id, PendingChangeKind.RevertTweak);
+        _pendingChanges.Add(new RevertTweakToCapturedChange(card));
     }
 
     [RelayCommand]

--- a/src/Perch.Desktop/Views/Pages/SystemTweaksPage.xaml
+++ b/src/Perch.Desktop/Views/Pages/SystemTweaksPage.xaml
@@ -386,9 +386,10 @@
                                                                     <Run Text="(" /><Run Text="{Binding Definition.Kind, Mode=OneWay}" /><Run Text=")" />
                                                                 </TextBlock>
                                                             </StackPanel>
-                                                            <!-- Three-value table: Current / Desired / Default -->
+                                                            <!-- Four-value table: Current / Desired / Captured / Default -->
                                                             <Grid Margin="0,4,0,0">
                                                                 <Grid.ColumnDefinitions>
+                                                                    <ColumnDefinition Width="*" />
                                                                     <ColumnDefinition Width="*" />
                                                                     <ColumnDefinition Width="*" />
                                                                     <ColumnDefinition Width="*" />
@@ -399,11 +400,13 @@
                                                                 </Grid.RowDefinitions>
                                                                 <TextBlock Grid.Row="0" Grid.Column="0" Text="Current" FontSize="9" Foreground="#666666" />
                                                                 <TextBlock Grid.Row="0" Grid.Column="1" Text="Desired" FontSize="9" Foreground="#666666" />
-                                                                <TextBlock Grid.Row="0" Grid.Column="2" Text="Default" FontSize="9" Foreground="#666666" />
+                                                                <TextBlock Grid.Row="0" Grid.Column="2" Text="Captured" FontSize="9" Foreground="#666666" />
+                                                                <TextBlock Grid.Row="0" Grid.Column="3" Text="Default" FontSize="9" Foreground="#666666" />
                                                                 <TextBlock Grid.Row="1" Grid.Column="0" Text="{Binding CurrentValue}" FontSize="10"
                                                                            Foreground="{Binding IsApplied, Converter={StaticResource BooleanToForegroundConverter}}" />
                                                                 <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Definition.Value}" FontSize="10" Foreground="#10B981" />
-                                                                <TextBlock Grid.Row="1" Grid.Column="2" Text="{Binding Definition.DefaultValue}" FontSize="10" Foreground="#888888" />
+                                                                <TextBlock Grid.Row="1" Grid.Column="2" Text="{Binding CapturedValue, TargetNullValue='—'}" FontSize="10" Foreground="#F59E0B" />
+                                                                <TextBlock Grid.Row="1" Grid.Column="3" Text="{Binding Definition.DefaultValue}" FontSize="10" Foreground="#888888" />
                                                             </Grid>
                                                         </StackPanel>
                                                     </DataTemplate>
@@ -426,6 +429,13 @@
                                                 Margin="0,0,6,0"
                                                 Visibility="{Binding Reversible, Converter={StaticResource BooleanToVisibilityConverter}}"
                                                 Click="OnRevertTweakClick" />
+                                            <ui:Button
+                                                Content="Revert to Captured"
+                                                Padding="8,4"
+                                                FontSize="11"
+                                                Margin="0,0,6,0"
+                                                Visibility="{Binding HasCapturedValues, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                                Click="OnRevertToCapturedClick" />
                                             <ui:Button
                                                 Icon="{ui:SymbolIcon FolderOpen16}"
                                                 ToolTip="Open in Regedit"

--- a/src/Perch.Desktop/Views/Pages/SystemTweaksPage.xaml.cs
+++ b/src/Perch.Desktop/Views/Pages/SystemTweaksPage.xaml.cs
@@ -67,6 +67,12 @@ public partial class SystemTweaksPage : Page
             ViewModel.RevertTweakCommand.Execute(card);
     }
 
+    private void OnRevertToCapturedClick(object sender, RoutedEventArgs e)
+    {
+        if (sender is FrameworkElement { DataContext: TweakCardModel card })
+            ViewModel.RevertTweakToCapturedCommand.Execute(card);
+    }
+
     private void OnOpenRegeditClick(object sender, RoutedEventArgs e)
     {
         if (sender is FrameworkElement { DataContext: TweakCardModel card })

--- a/tests/Perch.Core.Tests/Deploy/DeployServiceTests.cs
+++ b/tests/Perch.Core.Tests/Deploy/DeployServiceTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 using Perch.Core;
 using Perch.Core.Backup;
 using Perch.Core.Deploy;
+using Perch.Core.Fonts;
 using Perch.Core.Machines;
 using Perch.Core.Modules;
 using Perch.Core.Packages;
@@ -73,7 +74,7 @@ public sealed class DeployServiceTests
         _cleanFilterService.SetupAsync(Arg.Any<string>(), Arg.Any<ImmutableArray<AppModule>>(), Arg.Any<CancellationToken>())
             .Returns(ImmutableArray<CleanFilterResult>.Empty);
         _installResolver = Substitute.For<IInstallResolver>();
-        _deployService = new DeployService(_discoveryService, _orchestrator, _platformDetector, _globResolver, _snapshotProvider, _hookRunner, _machineProfileService, _registryProvider, _globalPackageInstaller, _vscodeExtensionInstaller, _psModuleInstaller, new PackageManifestParser(), new InstallManifestParser(), _installResolver, _systemPackageInstaller, new TemplateProcessor(), _referenceResolver, _variableResolver, _cleanFilterService);
+        _deployService = new DeployService(_discoveryService, _orchestrator, _platformDetector, _globResolver, _snapshotProvider, _hookRunner, _machineProfileService, _registryProvider, _globalPackageInstaller, _vscodeExtensionInstaller, _psModuleInstaller, new PackageManifestParser(), new InstallManifestParser(), _installResolver, _systemPackageInstaller, new TemplateProcessor(), _referenceResolver, _variableResolver, _cleanFilterService, new FontManifestParser());
         _reported = new List<DeployResult>();
         _progress = new SynchronousProgress<DeployResult>(r => _reported.Add(r));
     }
@@ -1890,6 +1891,88 @@ public sealed class DeployServiceTests
             await _deployService.DeployAsync(tempDir, new DeployOptions { DryRun = true, Progress = _progress });
 
             await _cleanFilterService.DidNotReceive().SetupAsync(Arg.Any<string>(), Arg.Any<ImmutableArray<AppModule>>(), Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Test]
+    public async Task DeployAsync_FontsYamlExists_InstallsFonts()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), $"perch-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        File.WriteAllText(Path.Combine(tempDir, "fonts.yaml"), """
+            - cascadia-code-nf
+            - meslo-nf
+            """);
+
+        try
+        {
+            _discoveryService.DiscoverAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+                .Returns(new DiscoveryResult(ImmutableArray<AppModule>.Empty, ImmutableArray<string>.Empty));
+
+            _installResolver.ResolveFontsAsync(Arg.Any<ImmutableArray<string>>(), Arg.Any<Platform>(), Arg.Any<CancellationToken>())
+                .Returns(new InstallResolution(
+                    ImmutableArray.Create(new PackageDefinition("cascadia-code-nerd-font", PackageManager.Chocolatey)),
+                    ImmutableArray<string>.Empty));
+
+            int exitCode = await _deployService.DeployAsync(tempDir, new DeployOptions { Progress = _progress });
+
+            Assert.That(exitCode, Is.EqualTo(0));
+            await _systemPackageInstaller.Received(1).InstallAsync("cascadia-code-nerd-font", PackageManager.Chocolatey, false, Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Test]
+    public async Task DeployAsync_FontsYamlDryRun_PassesDryRunToInstaller()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), $"perch-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        File.WriteAllText(Path.Combine(tempDir, "fonts.yaml"), """
+            - cascadia-code-nf
+            """);
+
+        try
+        {
+            _discoveryService.DiscoverAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+                .Returns(new DiscoveryResult(ImmutableArray<AppModule>.Empty, ImmutableArray<string>.Empty));
+
+            _installResolver.ResolveFontsAsync(Arg.Any<ImmutableArray<string>>(), Arg.Any<Platform>(), Arg.Any<CancellationToken>())
+                .Returns(new InstallResolution(
+                    ImmutableArray.Create(new PackageDefinition("cascadia-code-nerd-font", PackageManager.Chocolatey)),
+                    ImmutableArray<string>.Empty));
+
+            await _deployService.DeployAsync(tempDir, new DeployOptions { DryRun = true, Progress = _progress });
+
+            await _systemPackageInstaller.Received(1).InstallAsync("cascadia-code-nerd-font", PackageManager.Chocolatey, true, Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Test]
+    public async Task DeployAsync_NoFontsYaml_SkipsFonts()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), $"perch-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            _discoveryService.DiscoverAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+                .Returns(new DiscoveryResult(ImmutableArray<AppModule>.Empty, ImmutableArray<string>.Empty));
+
+            int exitCode = await _deployService.DeployAsync(tempDir, new DeployOptions { Progress = _progress });
+
+            Assert.That(exitCode, Is.EqualTo(0));
+            await _installResolver.DidNotReceive().ResolveFontsAsync(Arg.Any<ImmutableArray<string>>(), Arg.Any<Platform>(), Arg.Any<CancellationToken>());
         }
         finally
         {

--- a/tests/Perch.Core.Tests/Desktop/GalleryDetectionServiceTweakTests.cs
+++ b/tests/Perch.Core.Tests/Desktop/GalleryDetectionServiceTweakTests.cs
@@ -38,7 +38,7 @@ public sealed class GalleryDetectionServiceTweakTests
         var platformDetector = Substitute.For<IPlatformDetector>();
         platformDetector.CurrentPlatform.Returns(Platform.Windows);
 
-        _tweakService.Detect(Arg.Any<TweakCatalogEntry>())
+        _tweakService.DetectWithCaptureAsync(Arg.Any<TweakCatalogEntry>(), Arg.Any<CancellationToken>())
             .Returns(new TweakDetectionResult(TweakStatus.NotApplied, ImmutableArray<RegistryEntryStatus>.Empty));
 
         _service = new GalleryDetectionService(
@@ -137,7 +137,7 @@ public sealed class GalleryDetectionServiceTweakTests
         _catalog.GetAllTweaksAsync(Arg.Any<CancellationToken>())
             .Returns(ImmutableArray.Create(tweak));
 
-        _tweakService.Detect(tweak)
+        _tweakService.DetectWithCaptureAsync(tweak, Arg.Any<CancellationToken>())
             .Returns(new TweakDetectionResult(TweakStatus.NotApplied, ImmutableArray<RegistryEntryStatus>.Empty));
 
         var result = await _service.DetectTweaksAsync(
@@ -153,8 +153,8 @@ public sealed class GalleryDetectionServiceTweakTests
         _catalog.GetAllTweaksAsync(Arg.Any<CancellationToken>())
             .Returns(ImmutableArray.Create(tweak));
 
-        var entryStatus = new RegistryEntryStatus(tweak.Registry[0], 1, true);
-        _tweakService.Detect(tweak)
+        var entryStatus = new RegistryEntryStatus(tweak.Registry[0], 1, null, true);
+        _tweakService.DetectWithCaptureAsync(tweak, Arg.Any<CancellationToken>())
             .Returns(new TweakDetectionResult(TweakStatus.Applied, [entryStatus]));
 
         var result = await _service.DetectTweaksAsync(
@@ -175,9 +175,9 @@ public sealed class GalleryDetectionServiceTweakTests
             .Returns(ImmutableArray.Create(tweak));
 
         var entries = ImmutableArray.Create(
-            new RegistryEntryStatus(tweak.Registry[0], 1, true),
-            new RegistryEntryStatus(tweak.Registry[1], 99, false));
-        _tweakService.Detect(tweak)
+            new RegistryEntryStatus(tweak.Registry[0], 1, null, true),
+            new RegistryEntryStatus(tweak.Registry[1], 99, null, false));
+        _tweakService.DetectWithCaptureAsync(tweak, Arg.Any<CancellationToken>())
             .Returns(new TweakDetectionResult(TweakStatus.Partial, entries));
 
         var result = await _service.DetectTweaksAsync(

--- a/tests/Perch.Core.Tests/Registry/YamlCapturedRegistryStoreTests.cs
+++ b/tests/Perch.Core.Tests/Registry/YamlCapturedRegistryStoreTests.cs
@@ -1,0 +1,114 @@
+using Perch.Core.Registry;
+
+namespace Perch.Core.Tests.Registry;
+
+[TestFixture]
+public sealed class YamlCapturedRegistryStoreTests
+{
+    private string _tempDir = null!;
+    private string _filePath = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"perch-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _filePath = Path.Combine(_tempDir, "captured-registry.yaml");
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    [Test]
+    public async Task Load_FileDoesNotExist_ReturnsEmptyData()
+    {
+        var store = new YamlCapturedRegistryStore(_filePath);
+
+        var data = await store.LoadAsync();
+
+        Assert.That(data.Entries, Is.Empty);
+    }
+
+    [Test]
+    public async Task SaveAndLoad_RoundTrips()
+    {
+        var store = new YamlCapturedRegistryStore(_filePath);
+        var capturedAt = new DateTime(2025, 6, 15, 10, 0, 0, DateTimeKind.Utc);
+        var data = new CapturedRegistryData();
+        data.Entries[@"HKCU\Software\Test\Value1"] = new CapturedRegistryEntry
+        {
+            Value = "1", Kind = RegistryValueType.DWord, CapturedAt = capturedAt,
+        };
+        data.Entries[@"HKCU\Software\Test\Value2"] = new CapturedRegistryEntry
+        {
+            Value = "hello", Kind = RegistryValueType.String, CapturedAt = capturedAt,
+        };
+
+        await store.SaveAsync(data);
+        var loaded = await store.LoadAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(loaded.Entries, Has.Count.EqualTo(2));
+            Assert.That(loaded.Entries.ContainsKey(@"HKCU\Software\Test\Value1"), Is.True);
+            Assert.That(loaded.Entries.ContainsKey(@"HKCU\Software\Test\Value2"), Is.True);
+            Assert.That(loaded.Entries[@"HKCU\Software\Test\Value1"].Value, Is.EqualTo("1"));
+            Assert.That(loaded.Entries[@"HKCU\Software\Test\Value2"].Kind, Is.EqualTo(RegistryValueType.String));
+        });
+    }
+
+    [Test]
+    public async Task Save_CreatesDirectoryIfMissing()
+    {
+        var nestedPath = Path.Combine(_tempDir, "nested", "dir", "captured.yaml");
+        var store = new YamlCapturedRegistryStore(nestedPath);
+        var data = new CapturedRegistryData();
+
+        await store.SaveAsync(data);
+
+        Assert.That(File.Exists(nestedPath), Is.True);
+    }
+
+    [Test]
+    public async Task Load_CorruptFile_ReturnsEmptyData()
+    {
+        await File.WriteAllTextAsync(_filePath, "{{{{not valid yaml");
+        var store = new YamlCapturedRegistryStore(_filePath);
+
+        var data = await store.LoadAsync();
+
+        Assert.That(data.Entries, Is.Empty);
+    }
+
+    [Test]
+    public async Task Save_OverwritesExistingFile()
+    {
+        var store = new YamlCapturedRegistryStore(_filePath);
+        var capturedAt = DateTime.UtcNow;
+
+        var first = new CapturedRegistryData();
+        first.Entries["key1"] = new CapturedRegistryEntry
+        {
+            Value = "1", Kind = RegistryValueType.DWord, CapturedAt = capturedAt,
+        };
+        await store.SaveAsync(first);
+
+        var second = new CapturedRegistryData();
+        second.Entries["key2"] = new CapturedRegistryEntry
+        {
+            Value = "val", Kind = RegistryValueType.String, CapturedAt = capturedAt,
+        };
+        await store.SaveAsync(second);
+
+        var loaded = await store.LoadAsync();
+        Assert.Multiple(() =>
+        {
+            Assert.That(loaded.Entries, Has.Count.EqualTo(1));
+            Assert.That(loaded.Entries.ContainsKey("key2"), Is.True);
+        });
+    }
+}

--- a/tests/Perch.Core.Tests/Status/StatusServiceTests.cs
+++ b/tests/Perch.Core.Tests/Status/StatusServiceTests.cs
@@ -5,6 +5,8 @@ using Perch.Core.Packages;
 using Perch.Core.Registry;
 using Perch.Core.Status;
 using Perch.Core.Symlinks;
+using Perch.Core.Deploy;
+using Perch.Core.Fonts;
 using Perch.Core.Templates;
 
 namespace Perch.Core.Tests.Status;
@@ -44,7 +46,7 @@ public sealed class StatusServiceTests
         _progress = new SynchronousProgress<StatusResult>(r => _reported.Add(r));
     }
 
-    private StatusService CreateService(IRegistryProvider? registryProvider = null) =>
+    private StatusService CreateService(IRegistryProvider? registryProvider = null, IInstallResolver? installResolver = null) =>
         new(
             _discoveryService,
             _symlinkProvider,
@@ -55,7 +57,9 @@ public sealed class StatusServiceTests
             _packageManagerProviders,
             _packageManifestParser,
             _processRunner,
-            new TemplateProcessor());
+            new TemplateProcessor(),
+            new FontManifestParser(),
+            installResolver ?? Substitute.For<IInstallResolver>());
 
     [Test]
     public async Task CheckAsync_AllLinksCorrect_ReturnsZero()
@@ -1045,6 +1049,118 @@ public sealed class StatusServiceTests
                 Assert.That(_reported, Has.Count.EqualTo(1));
                 Assert.That(_reported[0].Level, Is.EqualTo(DriftLevel.Ok));
                 Assert.That(_reported[0].TargetPath, Is.EqualTo(targetFile));
+            });
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Test]
+    public async Task CheckAsync_FontInstalled_ReportsOk()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), $"perch-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        File.WriteAllText(Path.Combine(tempDir, "fonts.yaml"), """
+            - cascadia-code-nf
+            """);
+
+        try
+        {
+            var chocoProvider = Substitute.For<IPackageManagerProvider>();
+            chocoProvider.Manager.Returns(PackageManager.Chocolatey);
+            chocoProvider.ScanInstalledAsync(Arg.Any<CancellationToken>())
+                .Returns(new PackageManagerScanResult(true, ImmutableArray.Create(new InstalledPackage("cascadia-code-nerd-font", PackageManager.Chocolatey)), null));
+            _packageManagerProviders.Add(chocoProvider);
+
+            var installResolver = Substitute.For<IInstallResolver>();
+            installResolver.ResolveFontsAsync(Arg.Any<ImmutableArray<string>>(), Arg.Any<Platform>(), Arg.Any<CancellationToken>())
+                .Returns(new InstallResolution(
+                    ImmutableArray.Create(new PackageDefinition("cascadia-code-nerd-font", PackageManager.Chocolatey)),
+                    ImmutableArray<string>.Empty));
+
+            _statusService = CreateService(installResolver: installResolver);
+            _discoveryService.DiscoverAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+                .Returns(new DiscoveryResult(ImmutableArray<AppModule>.Empty, ImmutableArray<string>.Empty));
+
+            int exitCode = await _statusService.CheckAsync(tempDir, _progress);
+
+            var fontResults = _reported.Where(r => r.Category == StatusCategory.Font).ToList();
+            Assert.Multiple(() =>
+            {
+                Assert.That(exitCode, Is.EqualTo(0));
+                Assert.That(fontResults, Has.Count.EqualTo(1));
+                Assert.That(fontResults[0].Level, Is.EqualTo(DriftLevel.Ok));
+            });
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Test]
+    public async Task CheckAsync_FontMissing_ReportsMissing()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), $"perch-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        File.WriteAllText(Path.Combine(tempDir, "fonts.yaml"), """
+            - cascadia-code-nf
+            """);
+
+        try
+        {
+            var chocoProvider = Substitute.For<IPackageManagerProvider>();
+            chocoProvider.Manager.Returns(PackageManager.Chocolatey);
+            chocoProvider.ScanInstalledAsync(Arg.Any<CancellationToken>())
+                .Returns(new PackageManagerScanResult(true, ImmutableArray<InstalledPackage>.Empty, null));
+            _packageManagerProviders.Add(chocoProvider);
+
+            var installResolver = Substitute.For<IInstallResolver>();
+            installResolver.ResolveFontsAsync(Arg.Any<ImmutableArray<string>>(), Arg.Any<Platform>(), Arg.Any<CancellationToken>())
+                .Returns(new InstallResolution(
+                    ImmutableArray.Create(new PackageDefinition("cascadia-code-nerd-font", PackageManager.Chocolatey)),
+                    ImmutableArray<string>.Empty));
+
+            _statusService = CreateService(installResolver: installResolver);
+            _discoveryService.DiscoverAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+                .Returns(new DiscoveryResult(ImmutableArray<AppModule>.Empty, ImmutableArray<string>.Empty));
+
+            int exitCode = await _statusService.CheckAsync(tempDir, _progress);
+
+            var fontResults = _reported.Where(r => r.Category == StatusCategory.Font).ToList();
+            Assert.Multiple(() =>
+            {
+                Assert.That(exitCode, Is.EqualTo(1));
+                Assert.That(fontResults, Has.Count.EqualTo(1));
+                Assert.That(fontResults[0].Level, Is.EqualTo(DriftLevel.Missing));
+                Assert.That(fontResults[0].Message, Does.Contain("cascadia-code-nerd-font"));
+            });
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Test]
+    public async Task CheckAsync_NoFontsYaml_SkipsFontCheck()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), $"perch-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            _discoveryService.DiscoverAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+                .Returns(new DiscoveryResult(ImmutableArray<AppModule>.Empty, ImmutableArray<string>.Empty));
+
+            int exitCode = await _statusService.CheckAsync(tempDir, _progress);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(exitCode, Is.EqualTo(0));
+                Assert.That(_reported.Where(r => r.Category == StatusCategory.Font).ToList(), Is.Empty);
             });
         }
         finally

--- a/tests/Perch.Core.Tests/Tweaks/TweakServiceApplyTests.cs
+++ b/tests/Perch.Core.Tests/Tweaks/TweakServiceApplyTests.cs
@@ -20,7 +20,7 @@ public sealed class TweakServiceApplyTests
     public void SetUp()
     {
         _registry = Substitute.For<IRegistryProvider>();
-        _service = new TweakService(_registry);
+        _service = new TweakService(_registry, Substitute.For<ICapturedRegistryStore>());
     }
 
     [Test]

--- a/tests/Perch.Core.Tests/Tweaks/TweakServiceDetectTests.cs
+++ b/tests/Perch.Core.Tests/Tweaks/TweakServiceDetectTests.cs
@@ -19,7 +19,7 @@ public sealed class TweakServiceDetectTests
     public void SetUp()
     {
         _registry = Substitute.For<IRegistryProvider>();
-        _service = new TweakService(_registry);
+        _service = new TweakService(_registry, Substitute.For<ICapturedRegistryStore>());
     }
 
     [Test]

--- a/tests/Perch.Core.Tests/Tweaks/TweakServiceDetectWithCaptureTests.cs
+++ b/tests/Perch.Core.Tests/Tweaks/TweakServiceDetectWithCaptureTests.cs
@@ -1,0 +1,112 @@
+using System.Collections.Immutable;
+
+using NSubstitute;
+
+using Perch.Core.Catalog;
+using Perch.Core.Modules;
+using Perch.Core.Registry;
+using Perch.Core.Tweaks;
+
+namespace Perch.Core.Tests.Tweaks;
+
+[TestFixture]
+public sealed class TweakServiceDetectWithCaptureTests
+{
+    private IRegistryProvider _registry = null!;
+    private ICapturedRegistryStore _capturedStore = null!;
+    private TweakService _service = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _registry = Substitute.For<IRegistryProvider>();
+        _capturedStore = Substitute.For<ICapturedRegistryStore>();
+        _capturedStore.LoadAsync(Arg.Any<CancellationToken>())
+            .Returns(new CapturedRegistryData());
+        _service = new TweakService(_registry, _capturedStore);
+    }
+
+    [Test]
+    public async Task DetectWithCaptureAsync_AutoCapturesNewEntries()
+    {
+        _registry.GetValue(@"HKCU\Software\Test", "Value1").Returns(42);
+        var tweak = MakeTweak(
+            new RegistryEntryDefinition(@"HKCU\Software\Test", "Value1", 1, RegistryValueType.DWord));
+
+        var result = await _service.DetectWithCaptureAsync(tweak);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Entries[0].CapturedValue, Is.EqualTo("42"));
+            Assert.That(result.Entries[0].IsApplied, Is.False);
+        });
+        await _capturedStore.Received(1).SaveAsync(
+            Arg.Is<CapturedRegistryData>(d => d.Entries.ContainsKey(@"HKCU\Software\Test\Value1")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task DetectWithCaptureAsync_UsesExistingCapturedValue()
+    {
+        _registry.GetValue(@"HKCU\Software\Test", "Value1").Returns(1);
+        var capturedData = new CapturedRegistryData();
+        capturedData.Entries[@"HKCU\Software\Test\Value1"] = new CapturedRegistryEntry
+        {
+            Value = "99", Kind = RegistryValueType.DWord, CapturedAt = DateTime.UtcNow,
+        };
+        _capturedStore.LoadAsync(Arg.Any<CancellationToken>()).Returns(capturedData);
+
+        var tweak = MakeTweak(
+            new RegistryEntryDefinition(@"HKCU\Software\Test", "Value1", 1, RegistryValueType.DWord));
+
+        var result = await _service.DetectWithCaptureAsync(tweak);
+
+        Assert.That(result.Entries[0].CapturedValue, Is.EqualTo("99"));
+        await _capturedStore.DidNotReceive().SaveAsync(Arg.Any<CapturedRegistryData>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task DetectWithCaptureAsync_EmptyRegistry_ReturnsEmpty()
+    {
+        var tweak = new TweakCatalogEntry(
+            "empty", "Empty", "Test", [], null, true, [], ImmutableArray<RegistryEntryDefinition>.Empty);
+
+        var result = await _service.DetectWithCaptureAsync(tweak);
+
+        Assert.That(result.Entries, Is.Empty);
+        await _capturedStore.DidNotReceive().LoadAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task DetectWithCaptureAsync_NullCurrentValue_DoesNotCapture()
+    {
+        _registry.GetValue(@"HKCU\Software\Test", "Value1").Returns((object?)null);
+        var tweak = MakeTweak(
+            new RegistryEntryDefinition(@"HKCU\Software\Test", "Value1", 1, RegistryValueType.DWord));
+
+        var result = await _service.DetectWithCaptureAsync(tweak);
+
+        Assert.That(result.Entries[0].CapturedValue, Is.Null);
+        await _capturedStore.DidNotReceive().SaveAsync(Arg.Any<CapturedRegistryData>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task DetectWithCaptureAsync_PreservesDetectionStatus()
+    {
+        _registry.GetValue(@"HKCU\Software\Test", "Value1").Returns(1);
+        var tweak = MakeTweak(
+            new RegistryEntryDefinition(@"HKCU\Software\Test", "Value1", 1, RegistryValueType.DWord));
+
+        var result = await _service.DetectWithCaptureAsync(tweak);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Status, Is.EqualTo(TweakStatus.Applied));
+            Assert.That(result.Entries[0].IsApplied, Is.True);
+        });
+    }
+
+    private static TweakCatalogEntry MakeTweak(params RegistryEntryDefinition[] entries) =>
+        new("test-tweak", "Test Tweak", "Test", [], null, true, [],
+            entries.ToImmutableArray());
+}

--- a/tests/Perch.Core.Tests/Tweaks/TweakServiceRevertTests.cs
+++ b/tests/Perch.Core.Tests/Tweaks/TweakServiceRevertTests.cs
@@ -20,7 +20,7 @@ public sealed class TweakServiceRevertTests
     public void SetUp()
     {
         _registry = Substitute.For<IRegistryProvider>();
-        _service = new TweakService(_registry);
+        _service = new TweakService(_registry, Substitute.For<ICapturedRegistryStore>());
     }
 
     [Test]

--- a/tests/Perch.Core.Tests/Tweaks/TweakServiceRevertToCapturedTests.cs
+++ b/tests/Perch.Core.Tests/Tweaks/TweakServiceRevertToCapturedTests.cs
@@ -1,0 +1,106 @@
+using System.Collections.Immutable;
+
+using NSubstitute;
+
+using Perch.Core.Catalog;
+using Perch.Core.Deploy;
+using Perch.Core.Modules;
+using Perch.Core.Registry;
+using Perch.Core.Tweaks;
+
+namespace Perch.Core.Tests.Tweaks;
+
+[TestFixture]
+public sealed class TweakServiceRevertToCapturedTests
+{
+    private IRegistryProvider _registry = null!;
+    private ICapturedRegistryStore _capturedStore = null!;
+    private TweakService _service = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _registry = Substitute.For<IRegistryProvider>();
+        _capturedStore = Substitute.For<ICapturedRegistryStore>();
+        _capturedStore.LoadAsync(Arg.Any<CancellationToken>()).Returns(new CapturedRegistryData());
+        _service = new TweakService(_registry, _capturedStore);
+    }
+
+    [Test]
+    public async Task RevertToCaptured_UsesCapturedValue()
+    {
+        var captured = new CapturedRegistryData();
+        captured.Entries[@"HKCU\Software\Test\Value1"] = new CapturedRegistryEntry
+        {
+            Value = "99", Kind = RegistryValueType.DWord, CapturedAt = DateTime.UtcNow,
+        };
+        _capturedStore.LoadAsync(Arg.Any<CancellationToken>()).Returns(captured);
+
+        var tweak = MakeTweak(
+            new RegistryEntryDefinition(@"HKCU\Software\Test", "Value1", 1, RegistryValueType.DWord, 0));
+
+        var result = await _service.RevertToCapturedAsync(tweak);
+
+        Assert.That(result.Level, Is.EqualTo(ResultLevel.Ok));
+        _registry.Received(1).SetValue(@"HKCU\Software\Test", "Value1", "99", RegistryValueType.DWord);
+        Assert.That(result.Entries[0].Message, Does.Contain("Restored"));
+    }
+
+    [Test]
+    public async Task RevertToCaptured_FallsBackToDefaultValue()
+    {
+        var tweak = MakeTweak(
+            new RegistryEntryDefinition(@"HKCU\Software\Test", "Value1", 1, RegistryValueType.DWord, 42));
+
+        var result = await _service.RevertToCapturedAsync(tweak);
+
+        Assert.That(result.Level, Is.EqualTo(ResultLevel.Ok));
+        _registry.Received(1).SetValue(@"HKCU\Software\Test", "Value1", 42, RegistryValueType.DWord);
+    }
+
+    [Test]
+    public async Task RevertToCaptured_NoCapturedNoDefault_DeletesEntry()
+    {
+        var tweak = MakeTweak(
+            new RegistryEntryDefinition(@"HKCU\Software\Test", "Value1", 1, RegistryValueType.DWord));
+
+        var result = await _service.RevertToCapturedAsync(tweak);
+
+        _registry.Received(1).DeleteValue(@"HKCU\Software\Test", "Value1");
+        Assert.That(result.Entries[0].Message, Does.Contain("Deleted"));
+    }
+
+    [Test]
+    public async Task RevertToCaptured_DryRun_DoesNotWrite()
+    {
+        var captured = new CapturedRegistryData();
+        captured.Entries[@"HKCU\Software\Test\Value1"] = new CapturedRegistryEntry
+        {
+            Value = "99", Kind = RegistryValueType.DWord, CapturedAt = DateTime.UtcNow,
+        };
+        _capturedStore.LoadAsync(Arg.Any<CancellationToken>()).Returns(captured);
+
+        var tweak = MakeTweak(
+            new RegistryEntryDefinition(@"HKCU\Software\Test", "Value1", 1, RegistryValueType.DWord));
+
+        var result = await _service.RevertToCapturedAsync(tweak, dryRun: true);
+
+        Assert.That(result.Entries[0].Message, Does.Contain("Would restore"));
+        _registry.DidNotReceive().SetValue(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>(), Arg.Any<RegistryValueType>());
+    }
+
+    [Test]
+    public async Task RevertToCaptured_EmptyRegistry_ReturnsEmpty()
+    {
+        var tweak = new TweakCatalogEntry(
+            "empty", "Empty", "Test", [], null, true, [], ImmutableArray<RegistryEntryDefinition>.Empty);
+
+        var result = await _service.RevertToCapturedAsync(tweak);
+
+        Assert.That(result.Entries, Is.Empty);
+    }
+
+    private static TweakCatalogEntry MakeTweak(params RegistryEntryDefinition[] entries) =>
+        new("test-tweak", "Test Tweak", "Test", [], null, true, [],
+            entries.ToImmutableArray());
+}


### PR DESCRIPTION
## Summary
- Introduces captured registry values (pre-Perch machine state) alongside desired and default values, enabling "revert to pre-Perch state" vs "revert to Windows default"
- Auto-captures registry values on first detection, persisted in `%APPDATA%/perch/captured-registry.yaml`
- Desktop UI expanded to 4-column table (Current/Desired/Captured/Default) with dual revert buttons
- CLI: `--to-captured` flag on `tweak revert`, capture persistence in `registry-capture`

## Test Plan
- [ ] Verify `DetectWithCaptureAsync` auto-captures on first scan and reuses on subsequent scans
- [ ] Verify `RevertToCapturedAsync` uses captured values, falls back to defaults
- [ ] Verify 4-column layout renders correctly in expanded tweak cards
- [ ] Verify "Revert to Captured" button only shows when captured values exist
- [ ] Run `perch tweak revert <id> --to-captured` and confirm it restores captured state

Closes #82