### PR TITLE
Fix certificate text filter to show only matching certs

### DIFF
--- a/src/Perch.Desktop/ViewModels/SystemTweaksViewModel.cs
+++ b/src/Perch.Desktop/ViewModels/SystemTweaksViewModel.cs
@@ -503,11 +503,22 @@ public sealed partial class SystemTweaksViewModel : ViewModelBase
 
     private void ApplyCertificateFilter()
     {
+        var query = CertificateSearchText;
         FilteredCertificateGroups.Clear();
+
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            foreach (var group in _allCertificateGroups)
+                FilteredCertificateGroups.Add(group);
+            return;
+        }
+
         foreach (var group in _allCertificateGroups)
         {
-            if (group.MatchesSearch(CertificateSearchText))
-                FilteredCertificateGroups.Add(group);
+            var matching = group.Certificates.Where(c => c.MatchesSearch(query));
+            var filtered = new CertificateStoreGroupModel(group.Store, matching);
+            if (filtered.Certificates.Count > 0)
+                FilteredCertificateGroups.Add(filtered);
         }
     }
 


### PR DESCRIPTION
## Summary
- The certificate text filter was reusing original group objects containing all certs, so typing in the search box had no visible filtering effect
- Now creates new filtered groups with only matching certificates, hiding groups with zero matches
- Closes #94

## Test Plan
- [x] `dotnet build` -- zero warnings
- [x] `dotnet test` -- 18 certificate tests pass
- [x] Smoke test screenshot reviewed
- [ ] Launch app, navigate to Certificates, type a search term -- verify only matching certs shown