### PR TITLE
Fix regedit navigation to open at correct registry key

### DIFF
--- a/src/Perch.Desktop/Models/StartupCardModel.cs
+++ b/src/Perch.Desktop/Models/StartupCardModel.cs
@@ -1,6 +1,4 @@
-using System.ComponentModel;
 using System.Diagnostics;
-using System.Windows;
 
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -52,16 +50,10 @@ public partial class StartupCardModel : ObservableObject
                 break;
             case StartupSource.RegistryCurrentUser:
             case StartupSource.RegistryLocalMachine:
-                try
-                {
-                    var key = Entry.Source == StartupSource.RegistryCurrentUser
-                        ? @"HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Run"
-                        : @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run";
-                    Process.Start(new ProcessStartInfo("regedit", $"/m \"{key}\"") { UseShellExecute = true, Verb = "runas" });
-                }
-                catch (Win32Exception ex) when (ex.NativeErrorCode == 1223) // ERROR_CANCELLED (user declined UAC)
-                {
-                }
+                var key = Entry.Source == StartupSource.RegistryCurrentUser
+                    ? @"HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Run"
+                    : @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run";
+                RegeditLauncher.OpenAt(key);
                 break;
         }
     }

--- a/src/Perch.Desktop/RegeditLauncher.cs
+++ b/src/Perch.Desktop/RegeditLauncher.cs
@@ -1,0 +1,31 @@
+using System.Diagnostics;
+
+using Microsoft.Win32;
+
+namespace Perch.Desktop;
+
+internal static class RegeditLauncher
+{
+    internal static void OpenAt(string registryKeyPath)
+    {
+        using var applets = Registry.CurrentUser.CreateSubKey(
+            @"Software\Microsoft\Windows\CurrentVersion\Applets\Regedit");
+        applets.SetValue("LastKey", registryKeyPath);
+
+        bool needsElevation = registryKeyPath.StartsWith("HKEY_LOCAL_MACHINE", StringComparison.OrdinalIgnoreCase);
+        var psi = new ProcessStartInfo("regedit.exe") { UseShellExecute = true };
+        if (needsElevation)
+        {
+            psi.Verb = "runas";
+        }
+
+        try
+        {
+            Process.Start(psi);
+        }
+        catch (System.ComponentModel.Win32Exception ex) when (ex.NativeErrorCode == 1223)
+        {
+            // User declined UAC prompt
+        }
+    }
+}

--- a/src/Perch.Desktop/ViewModels/SystemTweaksViewModel.cs
+++ b/src/Perch.Desktop/ViewModels/SystemTweaksViewModel.cs
@@ -379,8 +379,7 @@ public sealed partial class SystemTweaksViewModel : ViewModelBase
         if (card.Registry.IsDefaultOrEmpty)
             return;
 
-        var key = card.Registry[0].Key;
-        Process.Start("regedit", $"/m \"{key}\"");
+        RegeditLauncher.OpenAt(card.Registry[0].Key);
     }
 
     [RelayCommand]


### PR DESCRIPTION
## Summary
- Replace invalid `/m` flag with `LastKey` registry approach for navigating regedit to a specific key
- Only elevate with UAC for HKLM keys, skip elevation for HKCU keys
- Extract shared `RegeditLauncher.OpenAt()` used by both startup page and tweaks page
- Closes #23

## Test Plan
- [x] `dotnet build` -- zero warnings
- [x] `dotnet test` -- all 1165 tests pass