### PR TITLE
Fix toggle pending badge not decrementing on second click

### DIFF
--- a/src/Perch.Desktop/Services/IPendingChangesService.cs
+++ b/src/Perch.Desktop/Services/IPendingChangesService.cs
@@ -10,5 +10,6 @@ public interface IPendingChangesService : INotifyPropertyChanged
     bool HasChanges { get; }
     void Add(PendingChange change);
     void Remove(string id, PendingChangeKind kind);
+    bool Contains(string id, PendingChangeKind kind);
     void Clear();
 }

--- a/src/Perch.Desktop/Services/PendingChangesService.cs
+++ b/src/Perch.Desktop/Services/PendingChangesService.cs
@@ -51,6 +51,17 @@ public sealed partial class PendingChangesService : ObservableObject, IPendingCh
         }
     }
 
+    public bool Contains(string id, PendingChangeKind kind)
+    {
+        for (int i = 0; i < _changes.Count; i++)
+        {
+            if (_changes[i].Id == id && _changes[i].Kind == kind)
+                return true;
+        }
+
+        return false;
+    }
+
     public void Clear() => _changes.Clear();
 
     private void OnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)

--- a/src/Perch.Desktop/ViewModels/AppsViewModel.cs
+++ b/src/Perch.Desktop/ViewModels/AppsViewModel.cs
@@ -188,14 +188,20 @@ public sealed partial class AppsViewModel : ViewModelBase
         if (!app.CanToggle)
             return;
 
-        if (app.IsManaged)
+        if (_pendingChanges.Contains(app.Id, PendingChangeKind.LinkApp))
         {
             _pendingChanges.Remove(app.Id, PendingChangeKind.LinkApp);
+        }
+        else if (_pendingChanges.Contains(app.Id, PendingChangeKind.UnlinkApp))
+        {
+            _pendingChanges.Remove(app.Id, PendingChangeKind.UnlinkApp);
+        }
+        else if (app.IsManaged)
+        {
             _pendingChanges.Add(new UnlinkAppChange(app));
         }
         else
         {
-            _pendingChanges.Remove(app.Id, PendingChangeKind.UnlinkApp);
             _pendingChanges.Add(new LinkAppChange(app));
         }
     }

--- a/src/Perch.Desktop/ViewModels/DotfilesViewModel.cs
+++ b/src/Perch.Desktop/ViewModels/DotfilesViewModel.cs
@@ -99,9 +99,9 @@ public sealed partial class DotfilesViewModel : ViewModelBase
     [RelayCommand]
     private void ToggleDotfile(AppCardModel app)
     {
-        if (app.IsManaged)
+        if (_pendingChanges.Contains(app.Id, PendingChangeKind.LinkDotfile))
             _pendingChanges.Remove(app.Id, PendingChangeKind.LinkDotfile);
-        else
+        else if (!app.IsManaged)
             _pendingChanges.Add(new LinkDotfileChange(app));
     }
 

--- a/tests/Perch.Core.Tests/Desktop/PendingChangesServiceTests.cs
+++ b/tests/Perch.Core.Tests/Desktop/PendingChangesServiceTests.cs
@@ -136,6 +136,56 @@ public sealed class PendingChangesServiceTests
     }
 
     [Test]
+    public void Contains_ExistingChange_ReturnsTrue()
+    {
+        _sut.Add(new LinkAppChange(CreateAppCard("app1")));
+
+        Assert.That(_sut.Contains("app1", PendingChangeKind.LinkApp), Is.True);
+    }
+
+    [Test]
+    public void Contains_WrongKind_ReturnsFalse()
+    {
+        _sut.Add(new LinkAppChange(CreateAppCard("app1")));
+
+        Assert.That(_sut.Contains("app1", PendingChangeKind.UnlinkApp), Is.False);
+    }
+
+    [Test]
+    public void Contains_NonExistentId_ReturnsFalse()
+    {
+        _sut.Add(new LinkAppChange(CreateAppCard("app1")));
+
+        Assert.That(_sut.Contains("app2", PendingChangeKind.LinkApp), Is.False);
+    }
+
+    [Test]
+    public void Contains_AfterRemove_ReturnsFalse()
+    {
+        _sut.Add(new LinkAppChange(CreateAppCard("app1")));
+        _sut.Remove("app1", PendingChangeKind.LinkApp);
+
+        Assert.That(_sut.Contains("app1", PendingChangeKind.LinkApp), Is.False);
+    }
+
+    [Test]
+    public void ToggleApp_SecondToggle_RemovesPendingChange()
+    {
+        var app = CreateAppCard("app1");
+        _sut.Add(new UnlinkAppChange(app));
+
+        Assert.That(_sut.Contains("app1", PendingChangeKind.UnlinkApp), Is.True);
+
+        _sut.Remove("app1", PendingChangeKind.UnlinkApp);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(_sut.Count, Is.Zero);
+            Assert.That(_sut.Contains("app1", PendingChangeKind.UnlinkApp), Is.False);
+        });
+    }
+
+    [Test]
     public void Add_MultipleTypes_TracksAll()
     {
         var app = CreateAppCard("app1");

--- a/tests/Perch.Core.Tests/Desktop/ViewModelTests.cs
+++ b/tests/Perch.Core.Tests/Desktop/ViewModelTests.cs
@@ -145,13 +145,27 @@ public sealed class AppsViewModelTests
     }
 
     [Test]
-    public void ToggleApp_Detected_RemovesPreviousUnlink()
+    public void ToggleApp_WithExistingLinkPending_RemovesIt()
     {
         var card = MakeCard("vscode", "Development/IDEs", CardStatus.Detected);
+        _pendingChanges.Contains(card.Id, PendingChangeKind.LinkApp).Returns(true);
+
+        _vm.ToggleAppCommand.Execute(card);
+
+        _pendingChanges.Received(1).Remove(card.Id, PendingChangeKind.LinkApp);
+        _pendingChanges.DidNotReceive().Add(Arg.Any<PendingChange>());
+    }
+
+    [Test]
+    public void ToggleApp_WithExistingUnlinkPending_RemovesIt()
+    {
+        var card = MakeCard("vscode", "Development/IDEs", CardStatus.Linked);
+        _pendingChanges.Contains(card.Id, PendingChangeKind.UnlinkApp).Returns(true);
 
         _vm.ToggleAppCommand.Execute(card);
 
         _pendingChanges.Received(1).Remove(card.Id, PendingChangeKind.UnlinkApp);
+        _pendingChanges.DidNotReceive().Add(Arg.Any<PendingChange>());
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- Add `Contains` method to `IPendingChangesService` to check for existing pending changes
- Fix `ToggleApp` in AppsViewModel to check for existing pending LinkApp/UnlinkApp before adding new ones
- Fix `ToggleDotfile` in DotfilesViewModel with same pattern
- Previously, toggling twice added duplicate changes instead of cancelling, because `IsManaged` (OneWay bound) never reflected pending state
- Closes #15

## Test Plan
- [x] `dotnet build` -- zero warnings
- [x] `dotnet test` -- 1171 pass
- [x] Smoke test screenshots reviewed (Apps + Dotfiles pages)