### PR TITLE
Handle manifest parse/read errors gracefully

### DIFF
--- a/src/Perch.Desktop/ViewModels/DashboardViewModel.cs
+++ b/src/Perch.Desktop/ViewModels/DashboardViewModel.cs
@@ -140,6 +140,12 @@ public sealed partial class DashboardViewModel : ViewModelBase
         {
             return;
         }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Failed to check status: {ex.Message}";
+            IsLoading = false;
+            return;
+        }
 
         var total = LinkedCount + AttentionCount + BrokenCount;
         HealthPercent = total > 0 ? (int)(LinkedCount * 100.0 / total) : 100;

--- a/tests/Perch.Core.Tests/Desktop/DashboardViewModelTests.cs
+++ b/tests/Perch.Core.Tests/Desktop/DashboardViewModelTests.cs
@@ -226,6 +226,21 @@ public sealed class DashboardViewModelTests
     }
 
     [Test]
+    public async Task RefreshAsync_StatusServiceThrows_ShowsErrorAndResetsLoading()
+    {
+        _statusService.CheckAsync(Arg.Any<string>(), Arg.Any<IProgress<StatusResult>>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("manifest is corrupted"));
+
+        await _vm.RefreshCommand.ExecuteAsync(null);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(_vm.IsLoading, Is.False);
+            Assert.That(_vm.StatusMessage, Does.Contain("manifest is corrupted"));
+        });
+    }
+
+    [Test]
     public void DiscardChange_RemovesSingleChange()
     {
         var app = CreateAppCard("app1");


### PR DESCRIPTION
## Summary
- Wrap per-module file read and parse in `ModuleDiscoveryService` with try-catch so one broken/locked manifest doesn't abort discovery of the rest
- Add `catch(Exception)` to `DashboardViewModel.RefreshAsync` to show error message and reset `IsLoading` on unexpected failures
- Previously, an IO error reading a single manifest.yaml would crash the entire discovery process
- Closes #13

## Test Plan
- [x] `dotnet build` -- zero warnings
- [x] `dotnet test` -- 1173 pass
- [x] New test: locked file produces error and continues discovery
- [x] New test: status service exception shows error and resets loading